### PR TITLE
Fix mixed fusion and broadcasting

### DIFF
--- a/dask_expr/collection.py
+++ b/dask_expr/collection.py
@@ -206,6 +206,7 @@ class FrameBase(DaskMethodsMixin):
         meta=no_default,
         enforce_metadata=True,
         transform_divisions=True,
+        clear_divisions=False,
         align_dataframes=False,
         **kwargs,
     ):
@@ -231,6 +232,9 @@ class FrameBase(DaskMethodsMixin):
         transform_divisions : bool, default True
             Whether to apply the function onto the divisions and apply those
             transformed divisions to the output.
+        clear_divisions : bool, default False
+            Whether divisions should be cleared. If True, `transform_divisions`
+            will be ignored.
         meta : Any, optional
             DataFrame object representing the schema of the expected result.
         """
@@ -249,6 +253,7 @@ class FrameBase(DaskMethodsMixin):
             meta,
             enforce_metadata,
             transform_divisions,
+            clear_divisions,
             kwargs,
             *[arg.expr if isinstance(arg, FrameBase) else arg for arg in args],
         )

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -543,6 +543,7 @@ class MapPartitions(Blockwise):
         "meta",
         "enforce_metadata",
         "transform_divisions",
+        "clear_divisions",
         "kwargs",
     ]
 
@@ -561,9 +562,14 @@ class MapPartitions(Blockwise):
         return _get_meta_map_partitions(args, [], self.func, self.kwargs, meta, None)
 
     def _divisions(self):
+        # Unknown divisions
+        if self.clear_divisions:
+            return (None,) * (self.frame.npartitions + 1)
+
+        # (Possibly) known divisions
         dfs = [arg for arg in self.args if isinstance(arg, Expr)]
         return _get_divisions_map_partitions(
-            False,  # Partitions must already be "aligned"
+            True,  # Partitions must already be "aligned"
             self.transform_divisions,
             dfs,
             self.func,
@@ -1017,11 +1023,16 @@ def optimize_blockwise_fusion(expr):
 
                 group.append(next)
                 for dep in dependencies[next]:
-                    if not (dependents[dep] - set(stack) - set(group)):
+                    if (dep.npartitions == root.npartitions) and not (
+                        dependents[dep] - set(stack) - set(group)
+                    ):
                         # All of deps dependents are contained
                         # in the local group (or the local stack
                         # of expr nodes that we know we will be
-                        # adding to the local group)
+                        # adding to the local group).
+                        # All nodes must also have the same number
+                        # of partitions, since broadcasting within
+                        # a group is not allowed.
                         stack.append(dep)
                     elif dep not in roots and dependencies[dep]:
                         # Couldn't fuse dep, but we may be able to
@@ -1114,6 +1125,10 @@ class Fused(Blockwise):
 
     def _divisions(self):
         return self.exprs[0]._divisions()
+
+    def _broadcast_dep(self, dep: Expr):
+        # Always broadcast single-partition dependencies in Fused
+        return dep.npartitions == 1
 
     def _task(self, index):
         graph = {self._name: (self.exprs[0]._name, index)}


### PR DESCRIPTION
While working on `Merge`, I found that we were incorrectly fusing `Blockwise` expressions with mismatched partition counts. We were also failing to broadcasts single-partition dependencies within `Fused` layers.

**Side Note**:
- This PR also adds a `clear_divisions` option to `MapPartitions` to make it possible to specify that the applied function should produce unknown divisions.