### PR TITLE
[Bug] Fix `pprint` for `Fused` expressions with unfused dependencies

### DIFF
--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -1085,16 +1085,22 @@ class Fused(Blockwise):
 
     def _tree_repr_lines(self, indent=0):
         lines = []
+        ext_indent = 0  # How far to indent "unfused" lines
         header = f"Fused({self._name[-5:]}):"
         for i, line in enumerate(self.exprs[0]._tree_repr_lines(2)):
             if i < len(self.exprs):
                 lines.append(line.replace(" ", "|", 1))
             else:
-                lines.append(line)
+                while True:
+                    c = line[ext_indent]
+                    if c != " ":
+                        break
+                    ext_indent += 1
+                break
 
-        for op in enumerate(self.operands[1:]):
+        for op in self.operands[1:]:
             if isinstance(op, Expr):
-                lines.extend(op._tree_repr_lines(2))
+                lines.extend(op._tree_repr_lines(ext_indent))
 
         lines = [header] + lines
         lines = [" " * indent + line for line in lines]

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -1085,17 +1085,13 @@ class Fused(Blockwise):
 
     def _tree_repr_lines(self, indent=0):
         lines = []
-        ext_indent = 0  # How far to indent "unfused" lines
+        ext_indent = 2  # How far to indent "unfused" lines
         header = f"Fused({self._name[-5:]}):"
         for i, line in enumerate(self.exprs[0]._tree_repr_lines(2)):
             if i < len(self.exprs):
                 lines.append(line.replace(" ", "|", 1))
             else:
-                while True:
-                    c = line[ext_indent]
-                    if c != " ":
-                        break
-                    ext_indent += 1
+                ext_indent = len(line) - len(line.lstrip(" "))
                 break
 
         for op in self.operands[1:]:


### PR DESCRIPTION
While adding a simple `Expr.visualize` method, I discovered that `pprint` indentation was a bit off for `Fused` expressions with unfused dependencies. This PR adds a simple fix.