### PR TITLE
Add abstract merge API

### DIFF
--- a/dask_expr/collection.py
+++ b/dask_expr/collection.py
@@ -14,6 +14,7 @@ from tlz import first
 
 from dask_expr import expr
 from dask_expr.expr import no_default
+from dask_expr.merge import Merge
 from dask_expr.repartition import Repartition
 
 #
@@ -322,6 +323,40 @@ class DataFrame(FrameBase):
                 raise TypeError(f"Column name cannot be type {type(k)}")
             result = new_collection(expr.Assign(result.expr, k, v.expr))
         return result
+
+    def merge(
+        self,
+        other,
+        how="inner",
+        on=None,
+        left_on=None,
+        right_on=None,
+        left_index=False,
+        right_index=False,
+        suffixes=("_x", "_y"),
+        indicator=False,
+        shuffle_backend=None,
+    ):
+        if isinstance(other, DataFrame):
+            other = other.expr
+            assert is_dataframe_like(other._meta)
+        else:
+            assert is_dataframe_like(other)
+        return new_collection(
+            Merge(
+                self.expr,
+                other,
+                how=how,
+                on=on,
+                left_on=left_on,
+                right_on=right_on,
+                left_index=left_index,
+                right_index=right_index,
+                suffixes=suffixes,
+                indicator=indicator,
+                shuffle_backend=shuffle_backend,
+            )
+        )
 
     def __setitem__(self, key, value):
         out = self.assign(**{key: value})

--- a/dask_expr/collection.py
+++ b/dask_expr/collection.py
@@ -460,7 +460,7 @@ def read_csv(*args, **kwargs):
 def read_parquet(
     path=None,
     columns=None,
-    filters=(),
+    filters=None,
     categories=None,
     index=None,
     storage_options=None,

--- a/dask_expr/collection.py
+++ b/dask_expr/collection.py
@@ -340,6 +340,7 @@ class DataFrame(FrameBase):
         right_index=False,
         suffixes=("_x", "_y"),
         indicator=False,
+        backend=None,
         shuffle_backend=None,
     ):
         if isinstance(other, DataFrame):
@@ -359,6 +360,7 @@ class DataFrame(FrameBase):
                 right_index=right_index,
                 suffixes=suffixes,
                 indicator=indicator,
+                backend=backend,
                 shuffle_backend=shuffle_backend,
             )
         )

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -546,6 +546,9 @@ class MapPartitions(Blockwise):
         "kwargs",
     ]
 
+    def __str__(self):
+        return f"MapPartitions({funcname(self.func)})"
+
     def _broadcast_dep(self, dep: Expr):
         # Always broadcast single-partition dependencies in MapPartitions
         return dep.npartitions == 1

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -64,13 +64,12 @@ class Expr:
     def __repr__(self):
         return str(self)
 
-    def _tree_repr_lines(self, indent=0, recurse=True):
+    def _tree_repr_lines(self, indent=0):
         header = funcname(type(self)) + ":"
         lines = []
         for i, op in enumerate(self.operands):
             if isinstance(op, Expr):
-                if recurse:
-                    lines.extend(op._tree_repr_lines(2))
+                lines.extend(op._tree_repr_lines(2))
             else:
                 try:
                     param = self._parameters[i]
@@ -1098,34 +1097,20 @@ class Fused(Blockwise):
     def _meta(self):
         return self.exprs[0]._meta
 
-    def _tree_repr_lines(self, indent=0, recurse=True):
-        header = f"Fused({self._name[-5:]}):"
-        if not recurse:
-            return [header]
-
-        seen = set()
+    def _tree_repr_lines(self, indent=0):
         lines = []
-        stack = [(self.exprs[0], 2)]
-        fused_group = [_expr._name for _expr in self.exprs]
-        dependencies = {dep._name: dep for dep in self.dependencies()}
-        while stack:
-            expr, _indent = stack.pop()
+        ext_indent = 2  # How far to indent "unfused" lines
+        header = f"Fused({self._name[-5:]}):"
+        for i, line in enumerate(self.exprs[0]._tree_repr_lines(2)):
+            if i < len(self.exprs):
+                lines.append(line.replace(" ", "|", 1))
+            else:
+                ext_indent = len(line) - len(line.lstrip(" "))
+                break
 
-            if expr._name in seen:
-                continue
-            seen.add(expr._name)
-
-            line = expr._tree_repr_lines(_indent, recurse=False)[0]
-            lines.append(line.replace(" ", "|", 1))
-            for dep in expr.dependencies():
-                if dep._name in fused_group:
-                    stack.append((dep, _indent + 2))
-                elif dep._name in dependencies:
-                    dependencies.pop(dep._name)
-                    lines.extend(dep._tree_repr_lines(_indent + 2))
-
-        for dep in dependencies.values():
-            lines.extend(dep._tree_repr_lines(2))
+        for op in self.operands[1:]:
+            if isinstance(op, Expr):
+                lines.extend(op._tree_repr_lines(ext_indent))
 
         lines = [header] + lines
         lines = [" " * indent + line for line in lines]

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -64,12 +64,13 @@ class Expr:
     def __repr__(self):
         return str(self)
 
-    def _tree_repr_lines(self, indent=0):
+    def _tree_repr_lines(self, indent=0, recurse=True):
         header = funcname(type(self)) + ":"
         lines = []
         for i, op in enumerate(self.operands):
             if isinstance(op, Expr):
-                lines.extend(op._tree_repr_lines(2))
+                if recurse:
+                    lines.extend(op._tree_repr_lines(2))
             else:
                 try:
                     param = self._parameters[i]
@@ -861,7 +862,7 @@ class Partitions(Expr):
 
     def _simplify_down(self):
         if isinstance(self.frame, Blockwise) and not isinstance(
-            self.frame, BlockwiseIO
+            self.frame, (BlockwiseIO, Fused)
         ):
             operands = [
                 Partitions(op, self.partitions)
@@ -1097,20 +1098,34 @@ class Fused(Blockwise):
     def _meta(self):
         return self.exprs[0]._meta
 
-    def _tree_repr_lines(self, indent=0):
-        lines = []
-        ext_indent = 2  # How far to indent "unfused" lines
+    def _tree_repr_lines(self, indent=0, recurse=True):
         header = f"Fused({self._name[-5:]}):"
-        for i, line in enumerate(self.exprs[0]._tree_repr_lines(2)):
-            if i < len(self.exprs):
-                lines.append(line.replace(" ", "|", 1))
-            else:
-                ext_indent = len(line) - len(line.lstrip(" "))
-                break
+        if not recurse:
+            return [header]
 
-        for op in self.operands[1:]:
-            if isinstance(op, Expr):
-                lines.extend(op._tree_repr_lines(ext_indent))
+        seen = set()
+        lines = []
+        stack = [(self.exprs[0], 2)]
+        fused_group = [_expr._name for _expr in self.exprs]
+        dependencies = {dep._name: dep for dep in self.dependencies()}
+        while stack:
+            expr, _indent = stack.pop()
+
+            if expr._name in seen:
+                continue
+            seen.add(expr._name)
+
+            line = expr._tree_repr_lines(_indent, recurse=False)[0]
+            lines.append(line.replace(" ", "|", 1))
+            for dep in expr.dependencies():
+                if dep._name in fused_group:
+                    stack.append((dep, _indent + 2))
+                elif dep._name in dependencies:
+                    dependencies.pop(dep._name)
+                    lines.extend(dep._tree_repr_lines(_indent + 2))
+
+        for dep in dependencies.values():
+            lines.extend(dep._tree_repr_lines(2))
 
         lines = [header] + lines
         lines = [" " * indent + line for line in lines]

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -785,6 +785,9 @@ class Projection(Elemwise):
         return f"{base}[{repr(self.columns)}]"
 
     def _simplify_down(self):
+        from dask_expr.merge import Merge
+        from dask_expr.shuffle import Shuffle
+
         if isinstance(self.frame, Projection):
             # df[a][b]
             a = self.frame.operand("columns")
@@ -798,6 +801,69 @@ class Projection(Elemwise):
                 assert b in a
 
             return self.frame.frame[b]
+
+        if isinstance(self.frame, Shuffle):
+            # Move the column projection to come
+            # before the abstract Shuffle
+            projection = self.operand("columns")
+            if isinstance(projection, (str, int)):
+                projection = [projection]
+
+            partitioning_index = self.frame.partitioning_index
+            if isinstance(partitioning_index, (str, int)):
+                partitioning_index = [partitioning_index]
+
+            target = self.frame.frame
+            new_projection = [
+                col
+                for col in target.columns
+                if (col in partitioning_index or col in projection)
+            ]
+            if set(new_projection) < set(target.columns):
+                return type(self.frame)(
+                    target[new_projection], *self.frame.operands[1:]
+                )[self.operand("columns")]
+
+        if isinstance(self.frame, Merge):
+            # Reorder the column projection to
+            # occur before the Merge
+            projection = self.operand("columns")
+            if isinstance(projection, (str, int)):
+                projection = [projection]
+
+            # Find columns to project on the left
+            left = self.frame.left
+            left_on = self.frame.left_on
+            left_suffix = self.frame.suffixes[0]
+            project_left = [
+                col
+                for col in left.columns
+                if (
+                    col in left_on
+                    or col in projection
+                    or f"{col}{left_suffix}" in projection
+                )
+            ]
+
+            # Find columns to project on the right
+            right = self.frame.right
+            right_on = self.frame.right_on
+            right_suffix = self.frame.suffixes[1]
+            project_right = [
+                col
+                for col in right.columns
+                if (
+                    col in right_on
+                    or col in projection
+                    or f"{col}{right_suffix}" in projection
+                )
+            ]
+            if set(project_left) < set(left.columns) or set(project_right) < set(
+                right.columns
+            ):
+                return type(self.frame)(
+                    left[project_left], right[project_right], *self.frame.operands[2:]
+                )[self.operand("columns")]
 
 
 class Index(Elemwise):

--- a/dask_expr/merge.py
+++ b/dask_expr/merge.py
@@ -1,10 +1,9 @@
 import functools
 
 from dask.dataframe.dispatch import make_meta, meta_nonempty
-from dask.utils import apply
+from dask.utils import M, apply
 
 from dask_expr.expr import Blockwise, Expr
-from dask_expr.io import FromPandas
 from dask_expr.repartition import Repartition
 from dask_expr.shuffle import Shuffle, _contains_index_name
 
@@ -16,26 +15,22 @@ class Merge(Expr):
         "left",
         "right",
         "how",
-        "on",
         "left_on",
         "right_on",
         "left_index",
         "right_index",
         "suffixes",
         "indicator",
-        "backend",
         "shuffle_backend",
     ]
     _defaults = {
         "how": "inner",
-        "on": None,
         "left_on": None,
         "right_on": None,
         "left_index": False,
         "right_index": False,
         "suffixes": ("_x", "_y"),
         "indicator": False,
-        "backend": None,
         "shuffle_backend": None,
     }
 
@@ -43,12 +38,11 @@ class Merge(Expr):
         return f"Merge({self._name[-7:]})"
 
     @property
-    def _kwargs(self):
+    def kwargs(self):
         return {
             k: self.operand(k)
             for k in [
                 "how",
-                "on",
                 "left_on",
                 "right_on",
                 "left_index",
@@ -60,86 +54,33 @@ class Merge(Expr):
 
     @functools.cached_property
     def _meta(self):
-        left = self._as_meta(self.left)
-        right = self._as_meta(self.right)
-        return left.merge(right, **self._kwargs)
+        left = meta_nonempty(self.left._meta)
+        right = meta_nonempty(self.right._meta)
+        return make_meta(left.merge(right, **self.kwargs))
 
     def _divisions(self):
-        npartitions_left = self._as_expr(self.left).npartitions
-        npartitions_right = self._as_expr(self.right).npartitions
+        npartitions_left = self.left.npartitions
+        npartitions_right = self.right.npartitions
         npartitions = max(npartitions_left, npartitions_right)
         return (None,) * (npartitions + 1)
 
-    @staticmethod
-    def _as_meta(dep, nonempty=True):
-        if isinstance(dep, Expr):
-            dep = dep._meta
-        return meta_nonempty(dep) if nonempty else make_meta(dep)
-
-    @staticmethod
-    def _as_expr(dep):
-        if isinstance(dep, Expr):
-            return dep
-        return FromPandas(dep, 1)
-
-    def _simplify_down(self):
+    def _lower(self):
         # Lower from an abstract expression using
         # logic in MergeBackend.from_abstract_merge
-        backend = self.backend or MergeBackend
-        if hasattr(backend, "from_abstract_merge"):
-            return backend.from_abstract_merge(self)
-        else:
-            raise ValueError(f"{backend} not supported")
 
-
-class MergeBackend(Merge):
-    """Base merge-backend class"""
-
-    def _simplify_down(self):
-        return None
-
-    @classmethod
-    def from_abstract_merge(cls, expr: Merge) -> Expr:
-        """Return a new Exprs to perform a merge"""
+        left = self.left
+        right = self.right
+        how = self.how
+        left_on = self.left_on
+        right_on = self.right_on
+        left_index = self.left_index
+        right_index = self.right_index
+        shuffle_backend = self.shuffle_backend
 
         # TODO:
         #  1. Handle mixed indexed merge
         #  2. Add multi-partition broadcast merge
         #  3. Add/leverage partition statistics
-
-        left = expr._as_expr(expr.left)
-        right = expr._as_expr(expr.right)
-        how = expr.how
-        on = expr.on
-        left_on = expr.left_on
-        right_on = expr.right_on
-        left_index = expr.left_index
-        right_index = expr.right_index
-
-        for o in [on, left_on, right_on]:
-            if isinstance(o, Expr):
-                raise NotImplementedError()
-        if (
-            not on
-            and not left_on
-            and not right_on
-            and not left_index
-            and not right_index
-        ):
-            on = [c for c in left.columns if c in right.columns]
-            if not on:
-                left_index = right_index = True
-
-        if on and not left_on and not right_on:
-            left_on = right_on = on
-            on = None
-
-        supported_how = ("left", "right", "outer", "inner")
-        if how not in supported_how:
-            raise ValueError(
-                f"dask.dataframe.merge does not support how='{how}'."
-                f"Options are: {supported_how}."
-            )
 
         # Check for "trivial" broadcast (single partition)
         npartitions = max(left.npartitions, right.npartitions)
@@ -150,7 +91,7 @@ class MergeBackend(Merge):
             or right.npartitions == 1
             and how in ("left", "inner")
         ):
-            return BlockwiseMerge(left, right, **expr._kwargs)
+            return BlockwiseMerge(left, right, **self.kwargs)
 
         # Check if we are merging on indices with known divisions
         merge_indexed_left = (
@@ -188,7 +129,7 @@ class MergeBackend(Merge):
                 left,
                 shuffle_left_on,
                 npartitions_out=npartitions,
-                backend=expr.shuffle_backend,
+                backend=shuffle_backend,
             )
 
         if shuffle_right_on:
@@ -197,30 +138,31 @@ class MergeBackend(Merge):
                 right,
                 shuffle_right_on,
                 npartitions_out=npartitions,
-                backend=expr.shuffle_backend,
+                backend=shuffle_backend,
             )
 
         # Blockwise merge
-        return BlockwiseMerge(left, right, **expr._kwargs)
+        return BlockwiseMerge(left, right, **self.kwargs)
+
+    def _simplify_down(self):
+        if type(self) == Merge:
+            # Only lower abstract objects
+            return self._lower()
 
 
-class BlockwiseMerge(MergeBackend, Blockwise):
-    """Base merge-backend class"""
+class BlockwiseMerge(Merge, Blockwise):
+    """Blockwise merge class"""
 
     def _broadcast_dep(self, dep: Expr):
         return dep.npartitions == 1
 
-    @staticmethod
-    def _merge_partition(df, other, **kwargs):
-        return df.merge(other, **kwargs)
-
     def _task(self, index: int):
         return (
             apply,
-            self._merge_partition,
+            M.merge,
             [
                 self._blockwise_arg(self.left, index),
                 self._blockwise_arg(self.right, index),
             ],
-            self._kwargs,
+            self.kwargs,
         )

--- a/dask_expr/merge.py
+++ b/dask_expr/merge.py
@@ -25,7 +25,6 @@ class Merge(Expr):
         "indicator",
         "backend",
         "shuffle_backend",
-        "_partitions",
     ]
     _defaults = {
         "how": "inner",
@@ -38,7 +37,6 @@ class Merge(Expr):
         "indicator": False,
         "backend": None,
         "shuffle_backend": None,
-        "_partitions": None,
     }
 
     def __str__(self):
@@ -171,6 +169,7 @@ class MergeBackend(Merge):
             else:
                 left = Repartition(left, new_divisions=right.divisions, force=True)
             shuffle_left_on = shuffle_right_on = None
+
         # TODO: Need 'rearrange_by_divisions' equivalent
         # to avoid shuffle when we are merging on known
         # divisions on one side only.

--- a/dask_expr/merge.py
+++ b/dask_expr/merge.py
@@ -101,6 +101,12 @@ class Merge(Expr):
             right_index or _contains_index_name(right, right_on)
         ) and right.known_divisions
 
+        # NOTE: Merging on an index is fragile. Pandas behavior
+        # depends on the actual data, and so we cannot use `meta`
+        # to accurately predict the output columns. Once general
+        # partition statistics are available, it may make sense
+        # to drop support for left_on and right_on.
+
         shuffle_left_on = left_on
         shuffle_right_on = right_on
         if merge_indexed_left and merge_indexed_right:
@@ -111,9 +117,11 @@ class Merge(Expr):
                 left = Repartition(left, new_divisions=right.divisions, force=True)
             shuffle_left_on = shuffle_right_on = None
 
-        # TODO: Need 'rearrange_by_divisions' equivalent
-        # to avoid shuffle when we are merging on known
-        # divisions on one side only.
+        # TODO:
+        #   - Need 'rearrange_by_divisions' equivalent
+        #     to avoid shuffle when we are merging on known
+        #     divisions on one side only.
+        #   - Need mechanism to shuffle by an un-named index.
         else:
             if left_index:
                 shuffle_left_on = left.index._meta.name

--- a/dask_expr/merge.py
+++ b/dask_expr/merge.py
@@ -105,7 +105,7 @@ class MergeBackend(Merge):
         """Return a new Exprs to perform a merge"""
 
         # TODO:
-        #  1. Handle mixed known-divisions
+        #  1. Handle mixed indexed merge
         #  2. Add multi-partition broadcast merge
         #  3. Add/leverage partition statistics
 

--- a/dask_expr/merge.py
+++ b/dask_expr/merge.py
@@ -147,7 +147,6 @@ class Merge(Expr):
                 shuffle_left_on,
                 npartitions_out=npartitions,
                 backend=shuffle_backend,
-                options={},
             )
 
         if shuffle_right_on:
@@ -157,7 +156,6 @@ class Merge(Expr):
                 shuffle_right_on,
                 npartitions_out=npartitions,
                 backend=shuffle_backend,
-                options={},
             )
 
         # Blockwise merge

--- a/dask_expr/merge.py
+++ b/dask_expr/merge.py
@@ -114,14 +114,15 @@ class Merge(Expr):
         # TODO: Need 'rearrange_by_divisions' equivalent
         # to avoid shuffle when we are merging on known
         # divisions on one side only.
-        elif left_index:
-            shuffle_left_on = left.index._meta.name
-            if shuffle_left_on is None:
-                raise NotImplementedError()
-        elif right_index:
-            shuffle_right_on = right.index._meta.name
-            if shuffle_right_on is None:
-                raise NotImplementedError()
+        else:
+            if left_index:
+                shuffle_left_on = left.index._meta.name
+                if shuffle_left_on is None:
+                    raise NotImplementedError()
+            if right_index:
+                shuffle_right_on = right.index._meta.name
+                if shuffle_right_on is None:
+                    raise NotImplementedError()
 
         if shuffle_left_on:
             # Shuffle left

--- a/dask_expr/merge.py
+++ b/dask_expr/merge.py
@@ -105,7 +105,7 @@ class Merge(Expr):
         # depends on the actual data, and so we cannot use `meta`
         # to accurately predict the output columns. Once general
         # partition statistics are available, it may make sense
-        # to drop support for left_on and right_on.
+        # to drop support for left_index and right_index.
 
         shuffle_left_on = left_on
         shuffle_right_on = right_on

--- a/dask_expr/merge.py
+++ b/dask_expr/merge.py
@@ -65,9 +65,7 @@ class Merge(Expr):
         return (None,) * (npartitions + 1)
 
     def _simplify_down(self):
-        # Lower from an abstract expression using
-        # logic in MergeBackend.from_abstract_merge
-
+        # Lower from an abstract expression
         left = self.left
         right = self.right
         how = self.how
@@ -78,7 +76,7 @@ class Merge(Expr):
         shuffle_backend = self.shuffle_backend
 
         # TODO:
-        #  1. Handle mixed indexed merge
+        #  1. Handle unnamed index with unknown divisions
         #  2. Add multi-partition broadcast merge
         #  3. Add/leverage partition statistics
 

--- a/dask_expr/merge.py
+++ b/dask_expr/merge.py
@@ -64,7 +64,7 @@ class Merge(Expr):
         npartitions = max(npartitions_left, npartitions_right)
         return (None,) * (npartitions + 1)
 
-    def _lower(self):
+    def _simplify_down(self):
         # Lower from an abstract expression using
         # logic in MergeBackend.from_abstract_merge
 
@@ -153,14 +153,12 @@ class Merge(Expr):
         # Blockwise merge
         return BlockwiseMerge(left, right, **self.kwargs)
 
-    def _simplify_down(self):
-        if type(self) == Merge:
-            # Only lower abstract objects
-            return self._lower()
-
 
 class BlockwiseMerge(Merge, Blockwise):
     """Blockwise merge class"""
+
+    def _simplify_down(self):
+        return None
 
     def _broadcast_dep(self, dep: Expr):
         return dep.npartitions == 1

--- a/dask_expr/merge.py
+++ b/dask_expr/merge.py
@@ -126,11 +126,11 @@ class Merge(Expr):
             if left_index:
                 shuffle_left_on = left.index._meta.name
                 if shuffle_left_on is None:
-                    raise NotImplementedError()
+                    raise NotImplementedError("Cannot shuffle unnamed index")
             if right_index:
                 shuffle_right_on = right.index._meta.name
                 if shuffle_right_on is None:
-                    raise NotImplementedError()
+                    raise NotImplementedError("Cannot shuffle unnamed index")
 
         if shuffle_left_on:
             # Shuffle left

--- a/dask_expr/merge.py
+++ b/dask_expr/merge.py
@@ -9,7 +9,17 @@ from dask_expr.shuffle import Shuffle, _contains_index_name
 
 
 class Merge(Expr):
-    """Abstract merge operation"""
+    """Merge / join two dataframes
+
+    This is an abstract class.  It will be transformed into a concrete
+    implementation before graph construction.
+
+    See Also
+    --------
+    BlockwiseMerge
+    Repartition
+    Shuffle
+    """
 
     _parameters = [
         "left",
@@ -137,6 +147,7 @@ class Merge(Expr):
                 shuffle_left_on,
                 npartitions_out=npartitions,
                 backend=shuffle_backend,
+                options={},
             )
 
         if shuffle_right_on:
@@ -146,6 +157,7 @@ class Merge(Expr):
                 shuffle_right_on,
                 npartitions_out=npartitions,
                 backend=shuffle_backend,
+                options={},
             )
 
         # Blockwise merge
@@ -195,7 +207,18 @@ class Merge(Expr):
 
 
 class BlockwiseMerge(Merge, Blockwise):
-    """Blockwise merge class"""
+    """Merge two dataframes with aligned partitions
+
+    This operation will directly merge partition i of the
+    left dataframe with partition i of the right dataframe.
+    The two dataframes must be shuffled or partitioned
+    by the merge key(s) before this operation is performed.
+    Single-partition dataframes will always be broadcasted.
+
+    See Also
+    --------
+    Merge
+    """
 
     def _simplify_down(self):
         return None

--- a/dask_expr/merge.py
+++ b/dask_expr/merge.py
@@ -1,0 +1,114 @@
+import functools
+
+from dask_expr.expr import Expr, MapPartitions
+from dask_expr.io import FromPandas
+from dask_expr.shuffle import Shuffle
+
+
+class Merge(Expr):
+    """Abstract merge operation"""
+
+    _parameters = [
+        "left",
+        "right",
+        "how",
+        "on",
+        "left_on",
+        "right_on",
+        "left_index",
+        "right_index",
+        "suffixes",
+        "indicator",
+        "shuffle_backend",
+    ]
+    _defaults = {
+        "how": "inner",
+        "on": None,
+        "left_on": None,
+        "right_on": None,
+        "left_index": False,
+        "right_index": False,
+        "suffixes": ("_x", "_y"),
+        "indicator": False,
+        "shuffle_backend": None,
+    }
+
+    def __str__(self):
+        return f"Merge({self._name[-7:]})"
+
+    @property
+    def _kwargs(self):
+        return {
+            k: self.operand(k)
+            for k in [
+                "how",
+                "on",
+                "left_on",
+                "right_on",
+                "left_index",
+                "right_index",
+                "suffixes",
+                "indicator",
+            ]
+        }
+
+    @functools.cached_property
+    def _meta(self):
+        if isinstance(self.right, Expr):
+            right = self.right._meta
+        else:
+            right = self.right.iloc[:0]
+        return self.left._meta.merge(right, **self._kwargs)
+
+    def _divisions(self):
+        npartitions_right = (
+            self.right.npartitions if isinstance(self.right, Expr) else 1
+        )
+        npartitions = max(self.left.npartitions, npartitions_right)
+        return (None,) * (npartitions + 1)
+
+    @staticmethod
+    def _merge_partition(df, other, **kwargs):
+        return df.merge(other, **kwargs)
+
+    def _simplify_down(self):
+        # TODO:
+        #  1. Handle merge on indices with known divisions
+        #  2. Handle broadcast merge
+        #  3. Add/leverage partition statistics
+
+        left = self.left
+        left_on = self.left_on or self.on
+        npartitions_left = self.left.npartitions
+
+        right = (
+            self.right if isinstance(self.right, Expr) else FromPandas(self.right, 1)
+        )
+        right_on = self.right_on or self.on
+        npartitions_right = (
+            self.right.npartitions if isinstance(self.right, Expr) else 1
+        )
+
+        npartitions_out = max(npartitions_left, npartitions_right)
+
+        # Shuffle left & right
+        left = Shuffle(
+            left, left_on, npartitions_out=npartitions_out, backend=self.shuffle_backend
+        )
+        right = Shuffle(
+            right,
+            right_on,
+            npartitions_out=npartitions_out,
+            backend=self.shuffle_backend,
+        )
+
+        # Partition-wise merge
+        return MapPartitions(
+            left,
+            self._merge_partition,
+            self._meta,
+            False,
+            True,
+            self._kwargs,
+            right,
+        )

--- a/dask_expr/merge.py
+++ b/dask_expr/merge.py
@@ -169,33 +169,33 @@ class Merge(Expr):
             if isinstance(projection, (str, int)):
                 projection = [projection]
 
+            left, right = self.left, self.right
+            left_on, right_on = self.left_on, self.right_on
+            left_suffix, right_suffix = self.suffixes[0], self.suffixes[1]
+            project_left, project_right = [], []
+
             # Find columns to project on the left
-            left = self.left
-            left_on = self.left_on
-            left_suffix = self.suffixes[0]
-            project_left = [
-                col
-                for col in left.columns
-                if (
-                    col in left_on
-                    or col in projection
-                    or f"{col}{left_suffix}" in projection
-                )
-            ]
+            for col in left.columns:
+                if col in left_on or col in projection:
+                    project_left.append(col)
+                elif f"{col}{left_suffix}" in projection:
+                    project_left.append(col)
+                    if col in right.columns:
+                        # Right column must be present
+                        # for the suffix to be applied
+                        project_right.append(col)
 
             # Find columns to project on the right
-            right = self.right
-            right_on = self.right_on
-            right_suffix = self.suffixes[1]
-            project_right = [
-                col
-                for col in right.columns
-                if (
-                    col in right_on
-                    or col in projection
-                    or f"{col}{right_suffix}" in projection
-                )
-            ]
+            for col in right.columns:
+                if col in right_on or col in projection:
+                    project_right.append(col)
+                elif f"{col}{right_suffix}" in projection:
+                    project_right.append(col)
+                    if col in left.columns and col not in project_left:
+                        # Left column must be present
+                        # for the suffix to be applied
+                        project_left.append(col)
+
             if set(project_left) < set(left.columns) or set(project_right) < set(
                 right.columns
             ):

--- a/dask_expr/shuffle.py
+++ b/dask_expr/shuffle.py
@@ -253,7 +253,7 @@ class TaskShuffle(SimpleShuffle):
     """Staged task-based shuffle implementation"""
 
     def _layer(self):
-        max_branch = self.options.get("max_branch", 32)
+        max_branch = (self.options or {}).get("max_branch", 32)
         npartitions_input = self.frame.npartitions
         if len(self._partitions) <= max_branch or npartitions_input <= max_branch:
             # We are creating a small number of output partitions,

--- a/dask_expr/shuffle.py
+++ b/dask_expr/shuffle.py
@@ -17,7 +17,7 @@ from dask.dataframe.shuffle import (
 )
 from dask.utils import digit, get_default_shuffle_algorithm, insert
 
-from dask_expr.expr import Assign, Blockwise, Expr
+from dask_expr.expr import Blockwise, Expr
 from dask_expr.repartition import Repartition
 
 
@@ -49,6 +49,11 @@ class Shuffle(Expr):
         "backend",
         "options",
     ]
+    _defaults = {
+        "ignore_index": False,
+        "backend": None,
+        "options": None,
+    }
 
     def __str__(self):
         return f"Shuffle({self._name[-7:]})"
@@ -121,7 +126,7 @@ class SimpleShuffle(ShuffleBackend):
         partitioning_index = expr.partitioning_index
         npartitions_out = expr.npartitions_out
         ignore_index = expr.ignore_index
-        options = expr.options
+        options = expr.options or {}
 
         # Normalize partitioning_index
         if isinstance(partitioning_index, str):
@@ -148,12 +153,12 @@ class SimpleShuffle(ShuffleBackend):
                     options,
                 )
 
-        # Assign partitioning-index as a new "_partitions" column
-        partitioning_index = _select_columns_or_index(frame, partitioning_index)
-        index_added = Assign(
+        # Assign new "_partitions" column
+        index_added = AssignPartitioningIndex(
             frame,
+            partitioning_index,
             "_partitions",
-            PartitioningIndex(frame, partitioning_index, npartitions_out),
+            npartitions_out,
         )
 
         # Apply shuffle
@@ -366,7 +371,7 @@ class DiskShuffle(SimpleShuffle):
 #
 
 
-def _select_columns_or_index(expr, columns_or_index):
+def _select_columns_or_index(df, columns_or_index):
     """
     Make a column selection that may include the index
 
@@ -381,17 +386,17 @@ def _select_columns_or_index(expr, columns_or_index):
         columns_or_index if isinstance(columns_or_index, list) else [columns_or_index]
     )
 
-    column_names = [n for n in columns_or_index if _is_column_label_reference(expr, n)]
+    column_names = [n for n in columns_or_index if _is_column_label_reference(df, n)]
 
-    selected_expr = expr[column_names]
-    if _contains_index_name(expr, columns_or_index):
+    selected_df = df[column_names]
+    if _contains_index_name(df, columns_or_index):
         # Index name was included
-        selected_expr = Assign(selected_expr, "_index", expr.index)
+        selected_df = selected_df.assign(_index=df.index)
 
-    return selected_expr
+    return selected_df
 
 
-def _is_column_label_reference(expr, key):
+def _is_column_label_reference(df, key):
     """
     Test whether a key is a column label reference
 
@@ -401,39 +406,39 @@ def _is_column_label_reference(expr, key):
     return (
         not isinstance(key, Expr)
         and (np.isscalar(key) or isinstance(key, tuple))
-        and key in expr.columns
+        and key in df.columns
     )
 
 
-def _contains_index_name(expr, columns_or_index):
+def _contains_index_name(df, columns_or_index):
     """
-    Test whether the input contains a reference to the index of the Expr
+    Test whether the input contains a reference to the index of the df
     """
     if isinstance(columns_or_index, list):
-        return any(_is_index_level_reference(expr, n) for n in columns_or_index)
+        return any(_is_index_level_reference(df, n) for n in columns_or_index)
     else:
-        return _is_index_level_reference(expr, columns_or_index)
+        return _is_index_level_reference(df, columns_or_index)
 
 
-def _is_index_level_reference(expr, key):
+def _is_index_level_reference(df, key):
     """
     Test whether a key is an index level reference
 
     To be considered an index level reference, `key` must match the index name
     and must NOT match the name of any column.
     """
-    index_name = expr.index._meta.name
+    index_name = df.index.name
     return (
         index_name is not None
         and not isinstance(key, Expr)
         and (np.isscalar(key) or isinstance(key, tuple))
         and key == index_name
-        and key not in getattr(expr, "columns", ())
+        and key not in getattr(df, "columns", ())
     )
 
 
-class PartitioningIndex(Blockwise):
-    """Create a partitioning index
+class AssignPartitioningIndex(Blockwise):
+    """Assign a partitioning index
 
     This class is used to construct a hash-based
     partitioning index for shuffling.
@@ -442,20 +447,25 @@ class PartitioningIndex(Blockwise):
     ----------
     frame: Expr
         Frame-like expression being partitioned.
-    index: Expr or list
+    partitioning_index: Expr or list
         Index-like expression or list of columns to construct
         the partitioning-index from.
+    index_name: str
+        New column name to assign.
     npartitions_out: int
         Number of partitions after repartitioning is finished.
     """
 
-    _parameters = ["frame", "index", "npartitions_out"]
+    _parameters = ["frame", "partitioning_index", "index_name", "npartitions_out"]
 
     @classmethod
-    def operation(cls, df, index, npartitions: int):
+    def operation(cls, df, index, name: str, npartitions: int):
         """Construct a hash-based partitioning index"""
+        index = _select_columns_or_index(df, index)
         if isinstance(index, (str, list, tuple)):
             # Assume column selection from df
             index = [index] if isinstance(index, str) else list(index)
-            return partitioning_index(df[index], npartitions)
-        return partitioning_index(index, npartitions)
+            index = partitioning_index(df[index], npartitions)
+        else:
+            index = partitioning_index(index, npartitions)
+        return df.assign(**{name: index})

--- a/dask_expr/shuffle.py
+++ b/dask_expr/shuffle.py
@@ -64,7 +64,7 @@ class Shuffle(Expr):
         # TODO: Support "p2p"
         backend = self.backend or get_default_shuffle_algorithm()
         backend = "tasks" if backend == "p2p" else backend
-        if isinstance(backend, ShuffleBackend):
+        if hasattr(backend, "from_abstract_shuffle"):
             return backend.from_abstract_shuffle(self)
         elif backend == "disk":
             return DiskShuffle.from_abstract_shuffle(self)

--- a/dask_expr/shuffle.py
+++ b/dask_expr/shuffle.py
@@ -452,7 +452,7 @@ def _is_index_level_reference(df, key):
     To be considered an index level reference, `key` must match the index name
     and must NOT match the name of any column.
     """
-    index_name = df.index.name
+    index_name = df.index._meta.name if isinstance(df, Expr) else df.index.name
     return (
         index_name is not None
         and not isinstance(key, Expr)

--- a/dask_expr/shuffle.py
+++ b/dask_expr/shuffle.py
@@ -155,7 +155,7 @@ class SimpleShuffle(PartitionsFiltered, ShuffleBackend):
         partitioning_index = expr.partitioning_index
         npartitions_out = expr.npartitions_out
         ignore_index = expr.ignore_index
-        options = expr.options or {}
+        options = expr.options
 
         # Normalize partitioning_index
         if isinstance(partitioning_index, str):

--- a/dask_expr/tests/test_merge.py
+++ b/dask_expr/tests/test_merge.py
@@ -26,6 +26,42 @@ def test_merge(opt, how, shuffle_backend):
 
 @pytest.mark.parametrize("opt", [True, False])
 @pytest.mark.parametrize("how", ["left", "right", "inner", "outer"])
+@pytest.mark.parametrize("pass_name", [True, False])
+@pytest.mark.parametrize("shuffle_backend", ["tasks", "disk"])
+def test_merge_indexed(opt, how, pass_name, shuffle_backend):
+    # Make simple left & right dfs
+    pdf1 = pd.DataFrame({"x": range(20), "y": range(20)})
+    df1 = from_pandas(pdf1, 4)
+    pdf2 = pd.DataFrame({"x": range(0, 20, 2), "z": range(10)}).set_index("x")
+    df2 = from_pandas(pdf2, 2)
+
+    # Partition-wise merge with map_partitions
+    left_index = True
+    right_index = False if pass_name else True
+    right_on = "x" if pass_name else None
+    df3 = df1.merge(
+        df2,
+        left_index=left_index,
+        right_index=right_index,
+        right_on=right_on,
+        how=how,
+        shuffle_backend=shuffle_backend,
+    )
+
+    # Check result with/without fusion
+    expect = pdf1.merge(
+        pdf2,
+        left_index=left_index,
+        right_index=right_index,
+        right_on=right_on,
+        how=how,
+    )
+    df3 = df3.optimize() if opt else df3
+    assert_eq(df3, expect)
+
+
+@pytest.mark.parametrize("opt", [True, False])
+@pytest.mark.parametrize("how", ["left", "right", "inner", "outer"])
 def test_broadcast_merge(opt, how):
     # Make simple left & right dfs
     pdf1 = pd.DataFrame({"x": range(20), "y": range(20)})

--- a/dask_expr/tests/test_merge.py
+++ b/dask_expr/tests/test_merge.py
@@ -86,12 +86,12 @@ def test_broadcast_merge(how):
 
 def test_merge_column_projection():
     # Make simple left & right dfs
-    pdf1 = pd.DataFrame({"x": range(20), "y": range(20)})
+    pdf1 = pd.DataFrame({"x": range(20), "y": range(20), "z": range(20)})
     df1 = from_pandas(pdf1, 4)
     pdf2 = pd.DataFrame({"x": range(0, 20, 2), "z": range(10)})
     df2 = from_pandas(pdf2, 2)
 
     # Partition-wise merge with map_partitions
-    df3 = df1.merge(df2, on="x")["z"].simplify()
+    df3 = df1.merge(df2, on="x")["z_x"].simplify()
 
     assert "y" not in df3.expr.operands[0].columns

--- a/dask_expr/tests/test_merge.py
+++ b/dask_expr/tests/test_merge.py
@@ -35,7 +35,6 @@ def test_merge_indexed(opt, how, pass_name, shuffle_backend):
     pdf2 = pd.DataFrame({"x": range(0, 20, 2), "z": range(10)}).set_index("x")
     df2 = from_pandas(pdf2, 2)
 
-    # Partition-wise merge with map_partitions
     left_index = True
     right_index = False if pass_name else True
     right_on = "x" if pass_name else None
@@ -69,7 +68,6 @@ def test_broadcast_merge(opt, how):
     pdf2 = pd.DataFrame({"x": range(0, 20, 2), "z": range(10)})
     df2 = from_pandas(pdf2, 1)
 
-    # Partition-wise merge with map_partitions
     df3 = df1.merge(df2, on="x", how=how)
 
     # Check that we avoid the shuffle when allowed
@@ -80,3 +78,16 @@ def test_broadcast_merge(opt, how):
     expect = pdf1.merge(pdf2, on="x", how=how)
     df3 = df3.optimize() if opt else df3
     assert_eq(df3, expect, check_index=False)
+
+
+def test_merge_column_projection():
+    # Make simple left & right dfs
+    pdf1 = pd.DataFrame({"x": range(20), "y": range(20)})
+    df1 = from_pandas(pdf1, 4)
+    pdf2 = pd.DataFrame({"x": range(0, 20, 2), "z": range(10)})
+    df2 = from_pandas(pdf2, 2)
+
+    # Partition-wise merge with map_partitions
+    df3 = df1.merge(df2, on="x")["z"].simplify()
+
+    assert "y" not in df3.expr.operands[0].columns

--- a/dask_expr/tests/test_merge.py
+++ b/dask_expr/tests/test_merge.py
@@ -1,0 +1,46 @@
+import pandas as pd
+import pytest
+from dask.dataframe.utils import assert_eq
+
+from dask_expr import from_pandas
+
+
+@pytest.mark.parametrize("opt", [True, False])
+@pytest.mark.parametrize("how", ["left", "right", "inner", "outer"])
+@pytest.mark.parametrize("shuffle_backend", ["tasks", "disk"])
+def test_merge(opt, how, shuffle_backend):
+    # Make simple left & right dfs
+    pdf1 = pd.DataFrame({"x": range(20), "y": range(20)})
+    df1 = from_pandas(pdf1, 4)
+    pdf2 = pd.DataFrame({"x": range(0, 20, 2), "z": range(10)})
+    df2 = from_pandas(pdf2, 2)
+
+    # Partition-wise merge with map_partitions
+    df3 = df1.merge(df2, on="x", how=how, shuffle_backend=shuffle_backend)
+
+    # Check result with/without fusion
+    expect = pdf1.merge(pdf2, on="x", how=how)
+    df3 = df3.optimize() if opt else df3
+    assert_eq(df3, expect, check_index=False)
+
+
+@pytest.mark.parametrize("opt", [True, False])
+@pytest.mark.parametrize("how", ["left", "right", "inner", "outer"])
+def test_broadcast_merge(opt, how):
+    # Make simple left & right dfs
+    pdf1 = pd.DataFrame({"x": range(20), "y": range(20)})
+    df1 = from_pandas(pdf1, 4)
+    pdf2 = pd.DataFrame({"x": range(0, 20, 2), "z": range(10)})
+    df2 = from_pandas(pdf2, 1)
+
+    # Partition-wise merge with map_partitions
+    df3 = df1.merge(df2, on="x", how=how)
+
+    # Check that we avoid the shuffle when allowed
+    if how in ("left", "inner"):
+        assert all(["Shuffle" not in str(op) for op in df3.simplify().operands[:2]])
+
+    # Check result with/without fusion
+    expect = pdf1.merge(pdf2, on="x", how=how)
+    df3 = df3.optimize() if opt else df3
+    assert_eq(df3, expect, check_index=False)

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -106,3 +106,11 @@ def test_task_shuffle_index(npartitions, max_branch):
     # partitions, this will fail
     df3 = df2.index.map_partitions(lambda x: x.drop_duplicates())
     assert sorted(df3.compute().tolist()) == list(range(20))
+
+
+def test_shuffle_column_projection():
+    pdf = pd.DataFrame({"x": list(range(20)) * 5, "y": range(100)})
+    df = from_pandas(pdf, npartitions=10)
+    df2 = df.shuffle("x")[["x"]].simplify()
+
+    assert "y" not in df2.expr.operands[0].columns


### PR DESCRIPTION
Adds `DataFrame.merge` and an abstract `Merge` expression.

Other changes in this PR:
- ~Fixes `Fused._tree_repr_lines` (again!)~ [**EDIT**: Moved to #64]
- Adds `dask_expr.shuffle.AssignPartitioningIndex` to simplify shuffle (replacing `Assign` + `PartitioningIndex`).

**TODO**:
- [x] `DataFrame.merge` docstring
- [x] Improve test coverage