### PR TITLE
Fix complex parquet filtering

### DIFF
--- a/dask_expr/collection.py
+++ b/dask_expr/collection.py
@@ -423,7 +423,7 @@ def read_csv(*args, **kwargs):
 def read_parquet(
     path=None,
     columns=None,
-    filters=(),
+    filters=None,
     categories=None,
     index=None,
     storage_options=None,

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import operator
 from functools import cached_property
 
 from dask.dataframe.io.parquet.core import (
@@ -11,7 +12,7 @@ from dask.dataframe.io.parquet.core import (
 from dask.dataframe.io.parquet.utils import _split_user_options
 from dask.utils import natural_sort_key
 
-from dask_expr.expr import EQ, GE, GT, LE, LT, NE, Filter, Projection
+from dask_expr.expr import EQ, GE, GT, LE, LT, NE, Expr, Filter, Projection
 from dask_expr.io import BlockwiseIO, PartitionsFiltered
 
 NONE_LABEL = "__null_dask_index__"
@@ -46,6 +47,7 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
         "filesystem",
         "kwargs",
         "_partitions",
+        "_series",
     ]
     _defaults = {
         "columns": None,
@@ -63,6 +65,7 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
         "filesystem": "fsspec",
         "kwargs": None,
         "_partitions": None,
+        "_series": False,
     }
 
     @property
@@ -85,6 +88,8 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
             operands[self._parameters.index("columns")] = _list_columns(
                 parent.operand("columns")
             )
+            if isinstance(parent.operand("columns"), (str, int)):
+                operands[self._parameters.index("_series")] = True
             return ReadParquet(*operands)
 
         if isinstance(parent, Filter) and isinstance(
@@ -94,15 +99,19 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
             if (
                 isinstance(parent.predicate.left, ReadParquet)
                 and parent.predicate.left.path == self.path
+                and not isinstance(parent.predicate.right, Expr)
             ):
                 op = parent.predicate._operator_repr
                 column = parent.predicate.left.columns[0]
                 value = parent.predicate.right
-                kwargs["filters"] = kwargs["filters"] + ((column, op, value),)
+                kwargs["filters"] = (kwargs["filters"] or tuple()) + (
+                    (column, op, value),
+                )
                 return ReadParquet(**kwargs)
             if (
                 isinstance(parent.predicate.right, ReadParquet)
                 and parent.predicate.right.path == self.path
+                and not isinstance(parent.predicate.left, Expr)
             ):
                 # Simple dict to make sure field comes first in filter
                 flip = {LE: GE, LT: GT, GE: LE, GT: LT}
@@ -110,7 +119,9 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
                 op = flip.get(op, op)._operator_repr
                 column = parent.predicate.right.columns[0]
                 value = parent.predicate.left
-                kwargs["filters"] = kwargs["filters"] + ((column, op, value),)
+                kwargs["filters"] = (kwargs["filters"] or tuple()) + (
+                    (column, op, value),
+                )
                 return ReadParquet(**kwargs)
 
     @cached_property
@@ -192,7 +203,10 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
 
     @property
     def _meta(self):
-        return self._dataset_info["meta"]
+        meta = self._dataset_info["meta"]
+        if self._series:
+            return meta[self.operand("columns")[0]]
+        return meta
 
     @cached_property
     def _plan(self):
@@ -246,4 +260,7 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
         return self._plan["divisions"]
 
     def _filtered_task(self, index: int):
-        return (self._plan["func"], self._plan["parts"][index])
+        tsk = (self._plan["func"], self._plan["parts"][index])
+        if self._series:
+            return (operator.getitem, tsk, self.columns[0])
+        return tsk

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -205,7 +205,8 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
     def _meta(self):
         meta = self._dataset_info["meta"]
         if self._series:
-            return meta[self.operand("columns")[0]]
+            column = _list_columns(self.operand("columns"))[0]
+            return meta[column]
         return meta
 
     @cached_property

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -106,9 +106,9 @@ def test_predicate_pushdown(tmpdir):
 
     # Check computed result
     y_result = y.compute()
-    assert list(y_result.columns) == ["b"]
-    assert len(y_result["b"]) == 6
-    assert all(y_result["b"] == 4)
+    assert y_result.name == "b"
+    assert len(y_result) == 6
+    assert all(y_result == 4)
 
 
 @pytest.mark.parametrize("fmt", ["parquet", "csv", "pandas"])
@@ -151,3 +151,13 @@ def test_from_pandas(sort):
 
     assert df.divisions == (0, 3, 5) if sort else (None,) * 3
     assert_eq(df, pdf)
+
+
+def test_parquet_complex_filters(tmpdir):
+    df = read_parquet(_make_file(tmpdir))
+    pdf = df.compute()
+    got = df["a"][df["b"] > df["b"].mean()]
+    expect = pdf["a"][pdf["b"] > pdf["b"].mean()]
+
+    assert_eq(got, expect)
+    assert_eq(got.optimize(), expect)


### PR DESCRIPTION
This fixes two subtle bugs related to parquet filtering and column projection:

1. `read_parquet(...)["a"]` currently produces a `DataFrame`, but *should* produce a `Series`.
2. We currently try to push down predicates like `df[df["a"] > df["a"].mean()]`

In order to fix both of these bugs while also continuing to support predicate pushdown for patterns like `df["a"][df["a"] > 1]`, I decided to add an optional `_series: bool = False` parameter to `ReadParquet`. When `_series=True`, the `ReadParquet` expression will now produce a `Series`.  (**Why**: When we disallow `ReadParquet` from producing a `Series`, a single-column `Projection` will block the `ReadParquet` from using `_simplify_up` on other `Filter` expressions.  This is because the `Projection` will always get stuck in-between the `ReadParquet` and the `Filter`.)