### PR TITLE
Basic groupby-aggregation support

### DIFF
--- a/dask_expr/collection.py
+++ b/dask_expr/collection.py
@@ -213,10 +213,10 @@ class FrameBase(DaskMethodsMixin):
             )
         )
 
-    # def groupby(self, *args, **kwargs):
-    #     from dask_expr.groupby import GroupByCollection
+    def groupby(self, *args, **kwargs):
+        from dask_expr.groupby import CollectionGroupBy
 
-    #     return GroupByCollection(self, *args, **kwargs)
+        return CollectionGroupBy(self, *args, **kwargs)
 
     def map_partitions(
         self,

--- a/dask_expr/collection.py
+++ b/dask_expr/collection.py
@@ -213,6 +213,11 @@ class FrameBase(DaskMethodsMixin):
             )
         )
 
+    # def groupby(self, *args, **kwargs):
+    #     from dask_expr.groupby import GroupByCollection
+
+    #     return GroupByCollection(self, *args, **kwargs)
+
     def map_partitions(
         self,
         func,

--- a/dask_expr/collection.py
+++ b/dask_expr/collection.py
@@ -214,9 +214,9 @@ class FrameBase(DaskMethodsMixin):
         )
 
     def groupby(self, *args, **kwargs):
-        from dask_expr.groupby import CollectionGroupBy
+        from dask_expr.groupby import GroupBy
 
-        return CollectionGroupBy(self, *args, **kwargs)
+        return GroupBy(self, *args, **kwargs)
 
     def map_partitions(
         self,

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -336,17 +336,17 @@ class Expr:
     def sum(self, skipna=True, numeric_only=None, min_count=0):
         return Sum(self, skipna, numeric_only, min_count)
 
-    def mean(self, skipna=True, numeric_only=None, min_count=0):
+    def mean(self, skipna=True, numeric_only=None):
         return Mean(self, skipna=skipna, numeric_only=numeric_only)
 
-    def max(self, skipna=True, numeric_only=None, min_count=0):
-        return Max(self, skipna, numeric_only, min_count)
+    def max(self, skipna=True, numeric_only=None):
+        return Max(self, skipna, numeric_only)
 
     def mode(self, dropna=True):
         return Mode(self, dropna=dropna)
 
-    def min(self, skipna=True, numeric_only=None, min_count=0):
-        return Min(self, skipna, numeric_only, min_count)
+    def min(self, skipna=True, numeric_only=None):
+        return Min(self, skipna, numeric_only)
 
     def count(self, numeric_only=None):
         return Count(self, numeric_only)

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -336,17 +336,17 @@ class Expr:
     def sum(self, skipna=True, numeric_only=None, min_count=0):
         return Sum(self, skipna, numeric_only, min_count)
 
-    def mean(self, skipna=True, numeric_only=None):
+    def mean(self, skipna=True, numeric_only=None, min_count=0):
         return Mean(self, skipna=skipna, numeric_only=numeric_only)
 
-    def max(self, skipna=True, numeric_only=None):
-        return Max(self, skipna, numeric_only)
+    def max(self, skipna=True, numeric_only=None, min_count=0):
+        return Max(self, skipna, numeric_only, min_count)
 
     def mode(self, dropna=True):
         return Mode(self, dropna=dropna)
 
-    def min(self, skipna=True, numeric_only=None):
-        return Min(self, skipna, numeric_only)
+    def min(self, skipna=True, numeric_only=None, min_count=0):
+        return Min(self, skipna, numeric_only, min_count)
 
     def count(self, numeric_only=None):
         return Count(self, numeric_only)

--- a/dask_expr/groupby.py
+++ b/dask_expr/groupby.py
@@ -1,0 +1,182 @@
+import functools
+
+from dask.dataframe.core import _concat
+
+# from dask.dataframe.groupby import _apply_chunk, _groupby_aggregate
+from dask.dataframe.groupby import _determine_levels, _groupby_raise_unaligned
+from dask.utils import M
+
+from dask_expr.collection import new_collection
+from dask_expr.expr import Expr
+from dask_expr.reductions import ApplyConcatApply
+
+###
+### Groupby Expression API
+###
+
+
+class GroupBy(Expr):
+    """Intermediate Groupby expresssion
+
+    This is an abstract class in the sense that it
+    cannot generate a task graph until it is converted
+    to a scalar, series, or dataframe-like expression.
+
+    Parameters
+    ----------
+    obj: Expr
+        Dataframe- or series-like expression to group
+    by: str, list or Series
+        The key for grouping
+    sort: bool
+        Whether the output aggregation should have sorted keys.
+    **options: dict
+        Other groupby options to pass through to backend.
+    """
+
+    _parameters = [
+        "obj",
+        "by",
+        "sort",
+        "options",
+    ]
+
+    def _layer(self):
+        raise NotImplementedError(
+            f"{self} is abstract! Please use the Grouby API to "
+            f"convert to a scalar, series, or dataframe-like "
+            f"object before computing."
+        )
+
+    def _single_agg(
+        self,
+        func,
+        aggfunc=None,
+        chunk_kwargs=None,
+        aggregate_kwargs=None,
+        split_out=1,
+        split_every=16,
+    ):
+        """Aggregation with a single function/aggfunc"""
+        if aggfunc is None:
+            aggfunc = func
+
+        if chunk_kwargs is None:
+            chunk_kwargs = {}
+
+        if aggregate_kwargs is None:
+            aggregate_kwargs = {}
+
+        frame = self.obj
+        by = self.by if isinstance(self.by, (list, tuple)) else [self.by]
+        levels = _determine_levels(by)
+
+        return SingleAgg(
+            frame,
+            by,
+            func,
+            chunk_kwargs,
+            aggfunc,
+            levels,
+            aggregate_kwargs,
+            self.options,
+            split_out,
+            split_every,
+        )
+
+    def count(self, split_out=1):
+        return self._single_agg(
+            func=M.count,
+            aggfunc=M.sum,
+            split_out=split_out,
+        )
+
+
+class SingleAgg(ApplyConcatApply):
+    _parameters = [
+        "frame",
+        "by",
+        "chunk",
+        "chunk_kwargs",
+        "aggregate",
+        "levels",
+        "aggregate_kwargs",
+        "groupby_kwargs",
+        "split_out",
+        "split_every",
+    ]
+
+    @staticmethod
+    def _apply_chunk(df, **kwargs):
+        func = kwargs.pop("chunk")
+        by = kwargs.pop("by")
+        groupby_kwargs = kwargs.pop("groupby_kwargs")
+        g = _groupby_raise_unaligned(df, by=by, **groupby_kwargs)
+        return func(g, **kwargs)
+
+    @staticmethod
+    def _groupby_aggregate(dfs, **kwargs):
+        aggfunc = kwargs.pop("aggfunc")
+        levels = kwargs.pop("levels")
+        groupby_kwargs = kwargs.pop("groupby_kwargs")
+        grouped = _concat(dfs).groupby(level=levels, **groupby_kwargs)
+        return aggfunc(grouped, **kwargs)
+
+    @functools.cached_property
+    def chunk(self):
+        return functools.partial(
+            self._apply_chunk,
+            by=self.operand("by"),
+            chunk=self.operand("chunk"),
+            groupby_kwargs=self.operand("groupby_kwargs"),
+        )
+
+    @functools.cached_property
+    def aggregate(self):
+        return functools.partial(
+            self._groupby_aggregate,
+            aggfunc=self.operand("aggregate"),
+            levels=self.operand("levels"),
+            groupby_kwargs=self.operand("groupby_kwargs"),
+        )
+
+    @property
+    def split_every(self):
+        return self.operand("split_every")
+
+    @property
+    def chunk_kwargs(self):
+        return self.operand("chunk_kwargs")
+
+    @property
+    def aggregate_kwargs(self):
+        return self.operand("aggregate_kwargs")
+
+
+###
+### Collection Groupby API
+###
+
+
+class CollectionGroupBy:
+    """Abstract Groupby-expression container"""
+
+    def __init__(
+        self,
+        obj,
+        by,
+        sort=True,
+        **options,
+    ):
+        for key in by if isinstance(by, (tuple, list)) else [by]:
+            if not isinstance(key, (str, int)):
+                raise NotImplementedError("Can only group on column names (for now).")
+
+        self._expr = GroupBy(obj.expr, by, sort, options)
+
+    @property
+    def expr(self):
+        return self._expr
+
+    def count(self, split_out=1):
+        return new_collection(self.expr.count(split_out=split_out))

--- a/dask_expr/groupby.py
+++ b/dask_expr/groupby.py
@@ -35,23 +35,7 @@ def _as_dict(key, value):
 ###
 
 
-class BaseAggregation(ApplyConcatApply):
-    """Groupby-aggregation base class
-
-    This class does very little besides provide a base
-    class for `SingleAggregation` and `GroupbyAggregation`.
-
-    See Also
-    --------
-    SingleAggregation
-    GroupbyAggregation
-    """
-
-    def _divisions(self):
-        return (None, None)
-
-
-class SingleAggregation(BaseAggregation):
+class SingleAggregation(ApplyConcatApply):
     """Single groupby aggregation
 
     This is an abstract class. Sub-classes must implement
@@ -136,7 +120,7 @@ class SingleAggregation(BaseAggregation):
         }
 
 
-class GroupbyAggregation(BaseAggregation):
+class GroupbyAggregation(ApplyConcatApply):
     """General groupby aggregation
 
     This class can be used directly to perform a general
@@ -175,10 +159,6 @@ class GroupbyAggregation(BaseAggregation):
         "dropna": None,
         "split_every": 8,
     }
-
-    @property
-    def split_every(self):
-        return self.operand("split_every")
 
     @functools.cached_property
     def spec(self):

--- a/dask_expr/groupby.py
+++ b/dask_expr/groupby.py
@@ -9,7 +9,6 @@ from dask.dataframe.core import (
     no_default,
 )
 from dask.dataframe.groupby import _apply_chunk, _determine_levels, _groupby_aggregate
-from dask.dataframe.utils import get_numeric_only_kwargs
 from dask.utils import M
 
 from dask_expr.collection import new_collection
@@ -193,8 +192,8 @@ class GroupBy:
             raise NotImplementedError("sort=True not yet supported.")
 
     def _numeric_only_kwargs(self, numeric_only):
-        numeric_kwargs = get_numeric_only_kwargs(numeric_only)
-        return {"chunk_kwargs": numeric_kwargs, "aggregate_kwargs": numeric_kwargs}
+        kwargs = {} if numeric_only is no_default else {"numeric_only": numeric_only}
+        return {"chunk_kwargs": kwargs, "aggregate_kwargs": kwargs}
 
     def _single_agg(
         self, expr_cls, split_out=1, chunk_kwargs=None, aggregate_kwargs=None

--- a/dask_expr/groupby.py
+++ b/dask_expr/groupby.py
@@ -16,7 +16,7 @@ from dask_expr.collection import new_collection
 from dask_expr.reductions import ApplyConcatApply
 
 ###
-### Groupby-Aggregation Expressions
+### Groupby-aggregation expressions
 ###
 
 
@@ -164,7 +164,7 @@ class GroupBy:
     """Collection container for groupby aggregations
 
     The purpose of this class is to expose an API similar
-    to Pandas' `Groupby`.
+    to Pandas' `Groupby` for dask-expr collections.
 
     See Also
     --------

--- a/dask_expr/reductions.py
+++ b/dask_expr/reductions.py
@@ -88,7 +88,7 @@ class ApplyConcatApply(Expr):
             ):
                 batch = list(batch)
                 if combine_kwargs:
-                    d[self._name, j, i] = (apply, combine, [batch], self.combine_kwargs)
+                    d[self._name, j, i] = (apply, combine, [batch], combine_kwargs)
                 else:
                     d[self._name, j, i] = (combine, batch)
                 new_keys.append((self._name, j, i))
@@ -109,8 +109,14 @@ class ApplyConcatApply(Expr):
         ]
         meta = self.chunk(meta, *args, **self.chunk_kwargs)
         aggregate = self.aggregate or (lambda x: x)
-        combine = self.combine or aggregate
-        meta = combine([meta], **self.combine_kwargs)
+        if self.combine:
+            combine = self.combine
+            combine_kwargs = self.combine_kwargs
+        else:
+            combine = aggregate
+            combine_kwargs = self.aggregate_kwargs
+
+        meta = combine([meta], **combine_kwargs)
         meta = aggregate([meta], **self.aggregate_kwargs)
         return make_meta(meta)
 

--- a/dask_expr/reductions.py
+++ b/dask_expr/reductions.py
@@ -34,7 +34,6 @@ class ApplyConcatApply(Expr):
     chunk = None
     combine = None
     aggregate = None
-    split_every = 0
     chunk_kwargs = {}
     combine_kwargs = {}
     aggregate_kwargs = {}
@@ -46,6 +45,7 @@ class ApplyConcatApply(Expr):
         # Normalize functions in case not all are defined
         chunk = self.chunk
         chunk_kwargs = self.chunk_kwargs
+        split_every = getattr(self, "split_every", 0)
 
         if self.aggregate:
             aggregate = self.aggregate
@@ -78,7 +78,7 @@ class ApplyConcatApply(Expr):
         while len(keys) > 1:
             new_keys = []
             for i, batch in enumerate(
-                toolz.partition_all(self.split_every or len(keys), keys)
+                toolz.partition_all(split_every or len(keys), keys)
             ):
                 batch = list(batch)
                 if combine_kwargs:
@@ -111,7 +111,7 @@ class ApplyConcatApply(Expr):
         return make_meta(meta)
 
     def _divisions(self):
-        return [None, None]
+        return (None, None)
 
 
 class Reduction(ApplyConcatApply):

--- a/dask_expr/tests/test_groupby.py
+++ b/dask_expr/tests/test_groupby.py
@@ -32,3 +32,11 @@ def test_groupby_count(pdf, df):
 
     expect = pdf.groupby("x").count()
     assert_eq(agg, expect)
+
+
+def test_groupby_aggregate(pdf, df):
+    g = df.groupby("x")
+    agg = g.aggregate({"x": "count"})
+
+    expect = pdf.groupby("x").aggregate({"x": "count"})
+    assert_eq(agg, expect)

--- a/dask_expr/tests/test_groupby.py
+++ b/dask_expr/tests/test_groupby.py
@@ -5,13 +5,30 @@ from dask.dataframe.utils import assert_eq
 from dask_expr import from_pandas
 
 
-@pytest.mark.parametrize("split_out", [1])
-def test_groupby_count(split_out):
+@pytest.fixture
+def pdf():
     pdf = pd.DataFrame({"x": list(range(10)) * 10, "y": range(100)})
-    df = from_pandas(pdf, npartitions=4)
+    yield pdf
 
+
+@pytest.fixture
+def df(pdf):
+    yield from_pandas(pdf, npartitions=4)
+
+
+@pytest.mark.parametrize("api", ["sum", "mean", "min", "max"])
+@pytest.mark.parametrize("numeric_only", [True, False])
+def test_groupby_numeric(pdf, df, api, numeric_only):
     g = df.groupby("x")
-    agg = g.count(split_out=split_out)
+    agg = getattr(g, api)(numeric_only=numeric_only)
+
+    expect = getattr(pdf.groupby("x"), api)(numeric_only=numeric_only)
+    assert_eq(agg, expect)
+
+
+def test_groupby_count(pdf, df):
+    g = df.groupby("x")
+    agg = g.count()
 
     expect = pdf.groupby("x").count()
     assert_eq(agg, expect)

--- a/dask_expr/tests/test_groupby.py
+++ b/dask_expr/tests/test_groupby.py
@@ -1,0 +1,17 @@
+import pandas as pd
+import pytest
+from dask.dataframe.utils import assert_eq
+
+from dask_expr import from_pandas
+
+
+@pytest.mark.parametrize("split_out", [1])
+def test_groupby_count(split_out):
+    pdf = pd.DataFrame({"x": list(range(10)) * 10, "y": range(100)})
+    df = from_pandas(pdf, npartitions=4)
+
+    g = df.groupby("x")
+    agg = g.count(split_out=split_out)
+
+    expect = pdf.groupby("x").count()
+    assert_eq(agg, expect)

--- a/dask_expr/tests/test_groupby.py
+++ b/dask_expr/tests/test_groupby.py
@@ -34,9 +34,29 @@ def test_groupby_count(pdf, df):
     assert_eq(agg, expect)
 
 
-def test_groupby_aggregate(pdf, df):
+@pytest.mark.parametrize(
+    "spec",
+    [
+        {"x": "count"},
+        {"x": ["count"]},
+        {"x": ["count"], "y": "mean"},
+        {"x": ["sum", "mean"]},
+        ["min", "mean"],
+        "sum",
+    ],
+)
+def test_groupby_agg(pdf, df, spec):
     g = df.groupby("x")
-    agg = g.aggregate({"x": "count"})
+    agg = g.agg(spec)
 
-    expect = pdf.groupby("x").aggregate({"x": "count"})
+    expect = pdf.groupby("x").agg(spec)
+    assert_eq(agg, expect)
+
+
+def test_groupby_agg_column_projection(pdf, df):
+    g = df.groupby("x")
+    agg = g.agg({"x": "count"}).simplify()
+
+    assert list(agg.frame.columns) == ["x"]
+    expect = pdf.groupby("x").agg({"x": "count"})
     assert_eq(agg, expect)


### PR DESCRIPTION
Adds basic groupby aggregations: `groupby.agg`, `groupby.count`, `groupby.sum`, `groupby.mean`, `groupby.min`, `groupby.max`

For now, this feature does not support `split_out>1`, SeriesGroupBy, or slicing an existing GroupBy object.
