### PR TITLE
Run CI against multiple Python versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,6 +18,11 @@ defaults:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+
     steps:
       - uses: actions/checkout@v2
 
@@ -26,6 +31,8 @@ jobs:
         with:
           environment-file: ci/environment.yml
           environment-name: dask-match
+          extra-specs: |
+            python=${{ matrix.python-version }}
 
       - name: Install Dask-Match
         run: python -m pip install -e . --no-deps

--- a/dask_expr/collection.py
+++ b/dask_expr/collection.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 
 import numpy as np

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import numbers
 import operator

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -417,7 +417,7 @@ class Expr:
     def __dask_keys__(self):
         return [(self._name, i) for i in range(self.npartitions)]
 
-    def substitute(self, substitutions: dict) -> "Expr":
+    def substitute(self, substitutions: dict) -> Expr:
         """Substitute specific `Expr` instances within `self`
 
         Parameters


### PR DESCRIPTION
I think the failures in https://github.com/coiled/benchmarks/pull/837 are related to lack of Python 3.9 support. Giving that a try here. 