### PR TITLE
Update package finding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,7 @@ dependencies = [
 ]
 
 dynamic = ["version"]
+
+[tool.setuptools.packages.find]
+exclude = ["*tests*"]
+namespaces = false

--- a/setup.py
+++ b/setup.py
@@ -4,5 +4,4 @@ from setuptools import setup
 
 setup(
     name="dask_expr",
-    packages=["dask_expr"],
 )


### PR DESCRIPTION
Fixes the `E   ModuleNotFoundError: No module named 'dask_expr.io'` error seen over in https://github.com/coiled/benchmarks/pull/837 (see [this CI build](https://github.com/coiled/benchmarks/actions/runs/4928923042/jobs/8807903176?pr=837)). Note this update is based on what we're doing over in `dask/dask` and `dask/distributed` 

cc @rjzamora 