### PR TITLE
Fix `Projection._meta`

### DIFF
--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import numbers
 import operator
@@ -425,7 +427,7 @@ class Expr:
     def __dask_keys__(self):
         return [(self._name, i) for i in range(self.npartitions)]
 
-    def substitute(self, substitutions: dict) -> "Expr":
+    def substitute(self, substitutions: dict) -> Expr:
         """Substitute specific `Expr` instances within `self`
 
         Parameters

--- a/dask_expr/reductions.py
+++ b/dask_expr/reductions.py
@@ -188,10 +188,6 @@ class Sum(Reduction):
             min_count=self.min_count,
         )
 
-    @property
-    def _meta(self):
-        return self.frame._meta.sum(**self.chunk_kwargs)
-
     def _simplify_up(self, parent):
         if isinstance(parent, Projection):
             return self.frame[parent.operand("columns")].sum(*self.operands[1:])

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -2,6 +2,7 @@ import operator
 import pickle
 
 import dask
+import numpy as np
 import pandas as pd
 import pytest
 from dask.dataframe.utils import assert_eq
@@ -47,7 +48,7 @@ def test_meta_divisions_name():
     assert list(df.columns) == list(a.columns)
     assert df.npartitions == 2
 
-    assert df.x.sum()._meta == 0
+    assert np.isscalar(df.x.sum()._meta)
     assert df.x.sum().npartitions == 1
 
     assert "mul" in df._name


### PR DESCRIPTION
- Fixes `Projection._meta` when the operand is a series-like expression
- Also modifies `_tree_repr_lines` to account for the fact that the underlying data may be something other than pandas (e.g. cudf)