### PR TITLE
Revise predicate-pushdown behavior in `ReadParquet`

### DIFF
--- a/dask_expr/collection.py
+++ b/dask_expr/collection.py
@@ -558,7 +558,7 @@ def read_parquet(
     filesystem="fsspec",
     **kwargs,
 ):
-    from dask_expr.io.parquet import ReadParquet, _list_columns  # , _normalize_filters
+    from dask_expr.io.parquet import ReadParquet, _list_columns
 
     if hasattr(path, "name"):
         path = stringify_path(path)
@@ -569,7 +569,6 @@ def read_parquet(
         ReadParquet(
             path,
             columns=_list_columns(columns),
-            # filters=_normalize_filters(filters),
             filters=filters,
             categories=categories,
             index=index,

--- a/dask_expr/collection.py
+++ b/dask_expr/collection.py
@@ -332,6 +332,8 @@ for op in [
     "__rge__",
     "__eq__",
     "__ne__",
+    "__and__",
+    "__or__",
 ]:
     setattr(FrameBase, op, functools.partialmethod(_wrap_expr_op, op=op))
 
@@ -556,7 +558,7 @@ def read_parquet(
     filesystem="fsspec",
     **kwargs,
 ):
-    from dask_expr.io.parquet import ReadParquet, _list_columns, _normalize_filters
+    from dask_expr.io.parquet import ReadParquet, _list_columns  # , _normalize_filters
 
     if hasattr(path, "name"):
         path = stringify_path(path)
@@ -567,7 +569,8 @@ def read_parquet(
         ReadParquet(
             path,
             columns=_list_columns(columns),
-            filters=_normalize_filters(filters),
+            # filters=_normalize_filters(filters),
+            filters=filters,
             categories=categories,
             index=index,
             storage_options=storage_options,

--- a/dask_expr/collection.py
+++ b/dask_expr/collection.py
@@ -556,7 +556,7 @@ def read_parquet(
     filesystem="fsspec",
     **kwargs,
 ):
-    from dask_expr.io.parquet import ReadParquet, _list_columns
+    from dask_expr.io.parquet import ReadParquet, _list_columns, _normalize_filters
 
     if hasattr(path, "name"):
         path = stringify_path(path)
@@ -567,7 +567,7 @@ def read_parquet(
         ReadParquet(
             path,
             columns=_list_columns(columns),
-            filters=filters,
+            filters=_normalize_filters(filters),
             categories=categories,
             index=index,
             storage_options=storage_options,

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -346,10 +346,10 @@ class Expr:
         return NE(other, self)
 
     def __and__(self, other):
-        return AND(other, self)
+        return And(other, self)
 
     def __or__(self, other):
-        return OR(other, self)
+        return Or(other, self)
 
     def sum(self, skipna=True, numeric_only=None, min_count=0):
         return Sum(self, skipna, numeric_only, min_count)
@@ -985,12 +985,12 @@ class NE(Binop):
     _operator_repr = "!="
 
 
-class AND(Binop):
+class And(Binop):
     operation = operator.and_
     _operator_repr = "&"
 
 
-class OR(Binop):
+class Or(Binop):
     operation = operator.or_
     _operator_repr = "|"
 

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -345,6 +345,12 @@ class Expr:
     def __ne__(self, other):
         return NE(other, self)
 
+    def __and__(self, other):
+        return AND(other, self)
+
+    def __or__(self, other):
+        return OR(other, self)
+
     def sum(self, skipna=True, numeric_only=None, min_count=0):
         return Sum(self, skipna, numeric_only, min_count)
 
@@ -977,6 +983,16 @@ class EQ(Binop):
 class NE(Binop):
     operation = operator.ne
     _operator_repr = "!="
+
+
+class AND(Binop):
+    operation = operator.and_
+    _operator_repr = "&"
+
+
+class OR(Binop):
+    operation = operator.or_
+    _operator_repr = "|"
 
 
 class Partitions(Expr):

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -299,12 +299,15 @@ class _DNF:
         if not filters:
             result = None
         elif isinstance(filters, list):
-            disjunction = []
-            stack = filters.copy()
-            while stack:
-                conjunction, *stack = stack if isinstance(stack[0], list) else [stack]
-                disjunction.append(cls._And(conjunction))
-            result = cls._Or(disjunction)
+            conjunctions = filters if isinstance(filters[0], list) else [filters]
+            result = cls._Or([cls._And(conjunction) for conjunction in conjunctions])
+
+            # disjunction = []
+            # stack = filters.copy()
+            # while stack:
+            #     conjunction, *stack = stack if isinstance(stack[0], list) else [stack]
+            #     disjunction.append(cls._And(conjunction))
+            # result = cls._Or(disjunction)
         elif isinstance(filters, tuple):
             if isinstance(filters[0], tuple):
                 raise TypeError("filters must be List[Tuple] or List[List[Tuple]]")

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -13,7 +13,7 @@ from dask.dataframe.io.parquet.core import (
 from dask.dataframe.io.parquet.utils import _split_user_options
 from dask.utils import natural_sort_key
 
-from dask_expr.expr import AND, EQ, GE, GT, LE, LT, NE, OR, Expr, Filter, Projection
+from dask_expr.expr import EQ, GE, GT, LE, LT, NE, And, Expr, Filter, Or, Projection
 from dask_expr.io import BlockwiseIO, PartitionsFiltered
 
 NONE_LABEL = "__null_dask_index__"
@@ -95,7 +95,7 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
             return ReadParquet(*operands)
 
         if isinstance(parent, Filter) and isinstance(
-            parent.predicate, (LE, GE, LT, GT, EQ, NE, AND, OR)
+            parent.predicate, (LE, GE, LT, GT, EQ, NE, And, Or)
         ):
             # Predicate pushdown
             filters = _DNF.extract_pq_filters(self, parent.predicate)
@@ -359,11 +359,11 @@ class _DNF:
                 value = predicate_expr.left
                 _filters = (column, op, value)
 
-        elif isinstance(predicate_expr, (AND, OR)):
+        elif isinstance(predicate_expr, (And, Or)):
             left = cls.extract_pq_filters(pq_expr, predicate_expr.left)._filters
             right = cls.extract_pq_filters(pq_expr, predicate_expr.right)._filters
             if left and right:
-                if isinstance(predicate_expr, AND):
+                if isinstance(predicate_expr, And):
                     _filters = cls._And([left, right])
                 else:
                     _filters = cls._Or([left, right])

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -301,13 +301,6 @@ class _DNF:
         elif isinstance(filters, list):
             conjunctions = filters if isinstance(filters[0], list) else [filters]
             result = cls._Or([cls._And(conjunction) for conjunction in conjunctions])
-
-            # disjunction = []
-            # stack = filters.copy()
-            # while stack:
-            #     conjunction, *stack = stack if isinstance(stack[0], list) else [stack]
-            #     disjunction.append(cls._And(conjunction))
-            # result = cls._Or(disjunction)
         elif isinstance(filters, tuple):
             if isinstance(filters[0], tuple):
                 raise TypeError("filters must be List[Tuple] or List[List[Tuple]]")

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -107,6 +107,44 @@ def test_predicate_pushdown(tmpdir):
     assert all(y_result == 4)
 
 
+def test_predicate_pushdown_compound(tmpdir):
+    pdf = pd.DataFrame(
+        {
+            "a": [1, 2, 3, 4, 5] * 10,
+            "b": [0, 1, 2, 3, 4] * 10,
+            "c": range(50),
+            "d": [6, 7] * 25,
+            "e": [8, 9] * 25,
+        }
+    )
+    fn = _make_file(tmpdir, format="parquet", df=pdf)
+    df = read_parquet(fn)
+
+    # Test AND
+    x = df[(df.a == 5) & (df.c > 20)]["b"]
+    y = optimize(x, fuse=False)
+    assert isinstance(y.expr, ReadParquet)
+    assert {("c", ">", 20), ("a", "==", 5)} == set(y.filters[0])
+    assert_eq(
+        y,
+        pdf[(pdf.a == 5) & (pdf.c > 20)]["b"],
+        check_index=False,
+    )
+
+    # Test OR
+    x = df[(df.a == 5) | (df.c > 20)][df.b != 0]["b"]
+    y = optimize(x, fuse=False)
+    assert isinstance(y.expr, ReadParquet)
+    filters = [set(y.filters[0]), set(y.filters[1])]
+    assert {("c", ">", 20), ("b", "!=", 0)} in filters
+    assert {("a", "==", 5), ("b", "!=", 0)} in filters
+    assert_eq(
+        y,
+        pdf[(pdf.a == 5) | (pdf.c > 20)][pdf.b != 0]["b"],
+        check_index=False,
+    )
+
+
 @pytest.mark.parametrize("fmt", ["parquet", "csv", "pandas"])
 def test_io_culling(tmpdir, fmt):
     pdf = pd.DataFrame({c: range(10) for c in "abcde"})

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -96,12 +96,8 @@ def test_predicate_pushdown(tmpdir):
     x = df[df.a == 5][df.c > 20]["b"]
     y = optimize(x, fuse=False)
     assert isinstance(y.expr, ReadParquet)
-    assert ("a", "==", 5) in y.expr.operand("filters") or (
-        "a",
-        "==",
-        5,
-    ) in y.expr.operand("filters")
-    assert ("c", ">", 20) in y.expr.operand("filters")
+    assert ("a", "==", 5) in y.expr.operand("filters")[0]
+    assert ("c", ">", 20) in y.expr.operand("filters")[0]
     assert list(y.columns) == ["b"]
 
     # Check computed result

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -144,6 +144,15 @@ def test_predicate_pushdown_compound(tmpdir):
         check_index=False,
     )
 
+    # Test OR and AND
+    x = df[((df.a == 5) | (df.c > 20)) & (df.b != 0)]["b"]
+    z = optimize(x, fuse=False)
+    assert isinstance(z.expr, ReadParquet)
+    filters = [set(z.filters[0]), set(z.filters[1])]
+    assert {("c", ">", 20), ("b", "!=", 0)} in filters
+    assert {("a", "==", 5), ("b", "!=", 0)} in filters
+    assert_eq(y, z)
+
 
 @pytest.mark.parametrize("fmt", ["parquet", "csv", "pandas"])
 def test_io_culling(tmpdir, fmt):

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -120,6 +120,17 @@ def test_conditionals(func, pdf, df):
 @pytest.mark.parametrize(
     "func",
     [
+        lambda df: df[(df.x > 10) | (df.x < 5)],
+        lambda df: df[(df.x > 7) & (df.x < 10)],
+    ],
+)
+def test_and_or(func, pdf, df):
+    assert_eq(func(pdf), func(df), check_names=False)
+
+
+@pytest.mark.parametrize(
+    "func",
+    [
         lambda df: df.astype(int),
         lambda df: df.apply(lambda row, x, y=10: row * x + y, x=2),
         lambda df: df[df.x > 5],


### PR DESCRIPTION
The current implementation of `Parquet._simplify_up` works for some simple cases, but it does not enforce proper disjunctive-normal form (DNF) using the `List[List[Tuple]]` convention in `dask.dataframe`.

This PR introduces an overhaul of the logic used to add new filters to an existing `ReadParquet` expression.