### PR TITLE
Add `Expr.statistics` method based on `Statistics`

### DIFF
--- a/dask_expr/collection.py
+++ b/dask_expr/collection.py
@@ -73,6 +73,12 @@ class FrameBase(DaskMethodsMixin):
     def size(self):
         return new_collection(self.expr.size)
 
+    def __len__(self):
+        _len = self.expr._len
+        if isinstance(_len, expr.Expr):
+            _len = new_collection(_len).compute()
+        return _len
+
     def __reduce__(self):
         return new_collection, (self._expr,)
 
@@ -546,7 +552,7 @@ def read_parquet(
     index=None,
     storage_options=None,
     dtype_backend=None,
-    calculate_divisions=False,
+    gather_statistics=True,
     ignore_metadata_file=False,
     metadata_task_size=None,
     split_row_groups="infer",
@@ -571,7 +577,7 @@ def read_parquet(
             categories=categories,
             index=index,
             storage_options=storage_options,
-            calculate_divisions=calculate_divisions,
+            gather_statistics=gather_statistics,
             ignore_metadata_file=ignore_metadata_file,
             metadata_task_size=metadata_task_size,
             split_row_groups=split_row_groups,

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -223,7 +223,7 @@ class Expr:
             for k, v in dep.statistics().items():
                 assert isinstance(v, Statistics)
                 if k not in statistics:
-                    val = v.inherit(self)
+                    val = v.assume(self)
                     if val:
                         statistics[k] = val
         return statistics

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -57,6 +57,11 @@ class Expr:
         except AttributeError:
             return 0
 
+    @functools.cached_property
+    def _len(self):
+        # TODO: Use single column
+        return Len(self)
+
     def __str__(self):
         s = ", ".join(
             str(param) + "=" + str(operand)
@@ -724,7 +729,10 @@ class Elemwise(Blockwise):
     optimizations, like `len` will care about which operations preserve length
     """
 
-    pass
+    @property
+    def _len(self):
+        # Length must be equal to parent
+        return self.frame._len
 
 
 class AsType(Elemwise):
@@ -1318,4 +1326,4 @@ class Fused(Blockwise):
 
 
 from dask_expr.io import BlockwiseIO
-from dask_expr.reductions import Count, Max, Mean, Min, Mode, Size, Sum
+from dask_expr.reductions import Count, Len, Max, Mean, Min, Mode, Size, Sum

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -217,7 +217,7 @@ class Expr:
         """New statistics to add for this expression"""
         from dask_expr.statistics import Statistics
 
-        # Inherit statistics from dependencies
+        # Assume statistics from dependencies
         statistics = {}
         for dep in self.dependencies():
             for k, v in dep.statistics().items():

--- a/dask_expr/io/io.py
+++ b/dask_expr/io/io.py
@@ -4,6 +4,7 @@ import math
 from dask.dataframe.io.io import sorted_division_locations
 
 from dask_expr.expr import Blockwise, Expr, PartitionsFiltered
+from dask_expr.metadata import RowCountMetadata
 
 
 class IO(Expr):
@@ -68,12 +69,12 @@ class FromPandas(PartitionsFiltered, BlockwiseIO):
             divisions = (None,) * len(locations)
         return divisions, locations
 
-    def _statistics(self):
+    def _metadata(self):
         locations = self._locations()
         row_counts = tuple(
             offset - locations[i] for i, offset in enumerate(locations[1:])
         )
-        return {"row_count": row_counts}
+        return {"row_count": RowCountMetadata(row_counts)}
 
     def _divisions(self):
         return self._divisions_and_locations[0]

--- a/dask_expr/io/io.py
+++ b/dask_expr/io/io.py
@@ -4,7 +4,7 @@ import math
 from dask.dataframe.io.io import sorted_division_locations
 
 from dask_expr.expr import Blockwise, Expr, PartitionsFiltered
-from dask_expr.metadata import RowCountMetadata
+from dask_expr.statistics import RowCountStatistics
 
 
 class IO(Expr):
@@ -69,12 +69,12 @@ class FromPandas(PartitionsFiltered, BlockwiseIO):
             divisions = (None,) * len(locations)
         return divisions, locations
 
-    def _metadata(self):
+    def _statistics(self):
         locations = self._locations()
         row_counts = tuple(
             offset - locations[i] for i, offset in enumerate(locations[1:])
         )
-        return {"row_count": RowCountMetadata(row_counts)}
+        return {"row_count": RowCountStatistics(row_counts)}
 
     def _divisions(self):
         return self._divisions_and_locations[0]

--- a/dask_expr/io/io.py
+++ b/dask_expr/io/io.py
@@ -68,6 +68,13 @@ class FromPandas(PartitionsFiltered, BlockwiseIO):
             divisions = (None,) * len(locations)
         return divisions, locations
 
+    def _statistics(self):
+        locations = self._locations()
+        row_counts = tuple(
+            offset - locations[i] for i, offset in enumerate(locations[1:])
+        )
+        return {"row_count": row_counts}
+
     def _divisions(self):
         return self._divisions_and_locations[0]
 

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -4,7 +4,6 @@ import itertools
 import operator
 from functools import cached_property
 
-import pandas as pd
 from dask.dataframe.io.parquet.core import (
     ParquetFunctionWrapper,
     aggregate_row_groups,
@@ -297,15 +296,14 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
             return (operator.getitem, tsk, self.columns[0])
         return tsk
 
-    @property
     def _statistics(self):
-        return self._plan["statistics"]
+        if self._pq_statistics and not self.filters:
+            row_count = tuple(stat["num-rows"] for stat in self._pq_statistics)
+            return {"row_count": row_count}
 
     @property
-    def _len(self):
-        if self._statistics and not self.filters:
-            return pd.DataFrame(self._statistics)["num-rows"].sum()
-        return super()._len
+    def _pq_statistics(self):
+        return self._plan["statistics"]
 
 
 #

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -16,6 +16,7 @@ from dask.utils import natural_sort_key
 
 from dask_expr.expr import EQ, GE, GT, LE, LT, NE, And, Expr, Filter, Or, Projection
 from dask_expr.io import BlockwiseIO, PartitionsFiltered
+from dask_expr.metadata import RowCountMetadata
 
 NONE_LABEL = "__null_dask_index__"
 
@@ -296,10 +297,10 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
             return (operator.getitem, tsk, self.columns[0])
         return tsk
 
-    def _statistics(self):
+    def _metadata(self):
         if self._pq_statistics and not self.filters:
             row_count = tuple(stat["num-rows"] for stat in self._pq_statistics)
-            return {"row_count": row_count}
+            return {"row_count": RowCountMetadata(row_count)}
 
     @property
     def _pq_statistics(self):

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -16,7 +16,7 @@ from dask.utils import natural_sort_key
 
 from dask_expr.expr import EQ, GE, GT, LE, LT, NE, And, Expr, Filter, Or, Projection
 from dask_expr.io import BlockwiseIO, PartitionsFiltered
-from dask_expr.metadata import RowCountMetadata
+from dask_expr.statistics import RowCountStatistics
 
 NONE_LABEL = "__null_dask_index__"
 
@@ -297,10 +297,10 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
             return (operator.getitem, tsk, self.columns[0])
         return tsk
 
-    def _metadata(self):
+    def _statistics(self):
         if self._pq_statistics and not self.filters:
             row_count = tuple(stat["num-rows"] for stat in self._pq_statistics)
-            return {"row_count": RowCountMetadata(row_count)}
+            return {"row_count": RowCountStatistics(row_count)}
 
     @property
     def _pq_statistics(self):

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -204,3 +204,14 @@ def test_parquet_complex_filters(tmpdir):
 
     assert_eq(got, expect)
     assert_eq(got.optimize(), expect)
+
+
+def test_parquet_row_count_statistics(tmpdir):
+    # NOTE: We should no longer need to set `index`
+    # or `calculate_divisions` to gather row-count
+    # statistics after dask#10290
+    df = read_parquet(_make_file(tmpdir), index="a", calculate_divisions=True)
+    pdf = df.compute()
+
+    s = (df["b"] + 1).astype("Int32")
+    assert s.statistics().get("row_count").sum() == len(pdf)

--- a/dask_expr/metadata.py
+++ b/dask_expr/metadata.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from functools import singledispatchmethod
+from typing import Any
+
+from dask_expr.expr import Elemwise, Expr, Partitions
+
+
+@dataclass(frozen=True)
+class Metadata:
+    """Abstract expression-metadata class
+
+    See Also
+    --------
+    StaticMetadata
+    PartitionMetadata
+    """
+
+    data: Any
+
+    @singledispatchmethod
+    def inherit(self, child: Expr) -> Metadata | None:
+        """New `Metadata` object that a "child" Expr mayinherit
+
+        A return value of `None` means that `type(Expr)` is
+        not eligable to inherit this kind of metadata.
+        """
+        return None
+
+
+@dataclass(frozen=True)
+class StaticMetadata(Metadata):
+    """A static metadata object
+
+    This metadata is not partition-specific, and can be
+    inherited by any child `Expr`.
+    """
+
+    def inherit(self, child: Expr) -> StaticMetadata:
+        return self
+
+
+@dataclass(frozen=True)
+class PartitionMetadata(Metadata):
+    """Metadata containing a distinct value for every partition
+
+    See Also
+    --------
+    RowCountMetadata
+    """
+
+    data: Iterable
+
+
+@PartitionMetadata.inherit.register
+def _partitionmetadata_partitions(self, child: Partitions):
+    # A `Partitions` expression may inherit metadata
+    # from the selected partitions
+    return type(self)(
+        type(self.data)(
+            part for i, part in enumerate(self.data) if i in child.partitions
+        )
+    )
+
+
+#
+# PartitionMetadata sub-classes
+#
+
+
+@dataclass(frozen=True)
+class RowCountMetadata(PartitionMetadata):
+    """Tracks the row count of each partition"""
+
+    def sum(self):
+        """Return the total row-count of all partitions"""
+        return sum(self.data)
+
+
+@RowCountMetadata.inherit.register
+def _rowcount_elemwise(self, child: Elemwise):
+    # All Element-wise operations may inherit
+    # row-count metadata "as is"
+    return self

--- a/dask_expr/statistics.py
+++ b/dask_expr/statistics.py
@@ -24,8 +24,8 @@ class Statistics:
         """Statistics that a "parent" Expr may assume
 
         A return value of `None` (the default) means that
-        `type(Expr)` is not eligable to assume these kind
-        of statistics.
+        `parent` is not eligable to assume this kind of
+        statistics.
         """
         return None
 

--- a/dask_expr/statistics.py
+++ b/dask_expr/statistics.py
@@ -10,7 +10,7 @@ from dask_expr.expr import Elemwise, Expr, Partitions
 
 @dataclass(frozen=True)
 class Statistics:
-    """Abstract expression-statistics class
+    """Abstract class for expression statistics
 
     See Also
     --------
@@ -23,8 +23,9 @@ class Statistics:
     def assume(self, parent: Expr) -> Statistics | None:
         """Statistics that a "parent" Expr may assume
 
-        A return value of `None` means that `type(Expr)` is
-        not eligable to assume these kind of statistics.
+        A return value of `None` (the default) means that
+        `type(Expr)` is not eligable to assume these kind
+        of statistics.
         """
         return None
 

--- a/dask_expr/statistics.py
+++ b/dask_expr/statistics.py
@@ -20,11 +20,11 @@ class Statistics:
     data: Any
 
     @singledispatchmethod
-    def inherit(self, child: Expr) -> Statistics | None:
-        """New `Statistics` object that a "child" Expr mayinherit
+    def assume(self, parent: Expr) -> Statistics | None:
+        """Statistics that a "parent" Expr may assume
 
         A return value of `None` means that `type(Expr)` is
-        not eligable to inherit this kind of statistics.
+        not eligable to assume these kind of statistics.
         """
         return None
 
@@ -41,13 +41,13 @@ class PartitionStatistics(Statistics):
     data: Iterable
 
 
-@PartitionStatistics.inherit.register
-def _partitionstatistics_partitions(self, child: Partitions):
-    # A `Partitions` expression may inherit statistics
+@PartitionStatistics.assume.register
+def _partitionstatistics_partitions(self, parent: Partitions):
+    # A `Partitions` expression may assume statistics
     # from the selected partitions
     return type(self)(
         type(self.data)(
-            part for i, part in enumerate(self.data) if i in child.partitions
+            part for i, part in enumerate(self.data) if i in parent.partitions
         )
     )
 
@@ -66,8 +66,8 @@ class RowCountStatistics(PartitionStatistics):
         return sum(self.data)
 
 
-@RowCountStatistics.inherit.register
-def _rowcount_elemwise(self, child: Elemwise):
-    # All Element-wise operations may inherit
-    # row-count statistics "as is"
+@RowCountStatistics.assume.register
+def _rowcount_elemwise(self, parent: Elemwise):
+    # All Element-wise operations may assume
+    # row-count statistics
     return self

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -431,13 +431,18 @@ def test_repartition_divisions(df, opt):
             assert part.max() < df2.divisions[p + 1]
 
 
-def test_statistics(df, pdf):
+def test_len(df, pdf):
     df2 = df[["x"]] + 1
     assert len(df2) == len(pdf)
-    assert df2.statistics().get("row_count").sum() == len(pdf)
-    assert df[df.x > 5].statistics().get("row_count") is None
 
-    # Check `partitions`
     first = df2.partitions[0].compute()
     assert len(df2.partitions[0]) == len(first)
-    assert df2.partitions[0].statistics().get("row_count").sum() == len(first)
+
+
+def test_row_count_statistics(df, pdf):
+    df2 = df[["x"]] + 1
+    assert df2.statistics().get("row_count").sum() == len(pdf)
+    assert df[df.x > 5].statistics().get("row_count") is None
+    assert df2.partitions[0].statistics().get("row_count").sum() == len(
+        df2.partitions[0]
+    )

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -429,3 +429,15 @@ def test_repartition_divisions(df, opt):
         if len(part):
             assert part.min() >= df2.divisions[p]
             assert part.max() < df2.divisions[p + 1]
+
+
+def test_statistics(df, pdf):
+    df2 = df[["x"]] + 1
+    assert len(df2) == len(pdf)
+    assert df2.metadata().get("row_count").sum() == len(pdf)
+    assert df[df.x > 5].metadata().get("row_count") is None
+
+    # Check `partitions`
+    first = df2.partitions[0].compute()
+    assert len(df2.partitions[0]) == len(first)
+    assert df2.partitions[0].metadata().get("row_count").sum() == len(first)

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -434,10 +434,10 @@ def test_repartition_divisions(df, opt):
 def test_statistics(df, pdf):
     df2 = df[["x"]] + 1
     assert len(df2) == len(pdf)
-    assert df2.metadata().get("row_count").sum() == len(pdf)
-    assert df[df.x > 5].metadata().get("row_count") is None
+    assert df2.statistics().get("row_count").sum() == len(pdf)
+    assert df[df.x > 5].statistics().get("row_count") is None
 
     # Check `partitions`
     first = df2.partitions[0].compute()
     assert len(df2.partitions[0]) == len(first)
-    assert df2.partitions[0].metadata().get("row_count").sum() == len(first)
+    assert df2.partitions[0].statistics().get("row_count").sum() == len(first)


### PR DESCRIPTION
Alternate take on https://github.com/mrocklin/dask-expr/pull/40

- Adds `dask_expr.statistics` module (defining a simple `dataclass` structure for statistics)
- Adds `Expr.statistics` (which utilizes `dask_expr.statistics`)
- Adds `FrameBase.__len__` (which utilizes `Expr.statistics` when possible)

**Rational for requiring `Expr.statistics: dict` to be `dask_expr.statistics.Statistics` instances**: It think we will be wanting to add/leverage many different kinds of "statistics." Therefore, I think we will need a class structure like this to simplify and isolate the logic that dictates if/how a specific `Expr` "parent" can assume a specific `Statistics` object from its child.