### PR TITLE
Implement ``memory_usage``

### DIFF
--- a/dask_expr/collection.py
+++ b/dask_expr/collection.py
@@ -17,6 +17,7 @@ from tlz import first
 from dask_expr import expr
 from dask_expr.expr import no_default
 from dask_expr.merge import Merge
+from dask_expr.reductions import MemoryUsageFrame, MemoryUsageIndex
 from dask_expr.repartition import Repartition
 
 #
@@ -482,6 +483,9 @@ class DataFrame(FrameBase):
     def __repr__(self):
         return f"<dask_expr.expr.DataFrame: expr={self.expr}>"
 
+    def memory_usage(self, deep=False, index=True):
+        return new_collection(MemoryUsageFrame(self.expr, deep=deep, _index=index))
+
 
 class Series(FrameBase):
     """Series-like Expr Collection"""
@@ -497,12 +501,18 @@ class Series(FrameBase):
     def __repr__(self):
         return f"<dask_expr.expr.Series: expr={self.expr}>"
 
+    def memory_usage(self, deep=False, index=True):
+        return new_collection(MemoryUsageFrame(self.expr, deep=deep, _index=index))
+
 
 class Index(Series):
     """Index-like Expr Collection"""
 
     def __repr__(self):
         return f"<dask_expr.expr.Index: expr={self.expr}>"
+
+    def memory_usage(self, deep=False):
+        return new_collection(MemoryUsageIndex(self.expr, deep=deep))
 
 
 class Scalar(FrameBase):

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -398,17 +398,6 @@ class Expr:
             raise NotImplementedError("value_counts not implemented for DataFrame")
         return ValueCounts(self, sort, ascending, dropna, normalize)
 
-    def memory_usage(self, deep=False, index=no_default):
-        if is_index_like(self._meta):
-            if index is not no_default:
-                raise TypeError(
-                    "index key-word is not supported when calculating memory_usage of index"
-                )
-            return MemoryUsage(self, deep=deep)
-        if index is no_default:
-            index = True
-        return MemoryUsage(self, deep=deep, _index=index)
-
     def min(self, skipna=True, numeric_only=False, min_count=0):
         return Min(self, skipna, numeric_only, min_count)
 
@@ -1397,7 +1386,6 @@ from dask_expr.reductions import (
     IdxMin,
     Max,
     Mean,
-    MemoryUsage,
     Min,
     Mode,
     NBytes,

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -407,7 +407,7 @@ class Expr:
             return MemoryUsage(self, deep=deep)
         if index is no_default:
             index = True
-        return MemoryUsage(self, deep=deep, index=index)
+        return MemoryUsage(self, deep=deep, _index=index)
 
     def min(self, skipna=True, numeric_only=False, min_count=0):
         return Min(self, skipna, numeric_only, min_count)

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -398,6 +398,17 @@ class Expr:
             raise NotImplementedError("value_counts not implemented for DataFrame")
         return ValueCounts(self, sort, ascending, dropna, normalize)
 
+    def memory_usage(self, deep=False, index=no_default):
+        if is_index_like(self._meta):
+            if index is not no_default:
+                raise TypeError(
+                    "index key-word is not supported when calculating memory_usage of index"
+                )
+            return MemoryUsage(self, deep=deep)
+        if index is no_default:
+            index = True
+        return MemoryUsage(self, deep=deep, index=index)
+
     def min(self, skipna=True, numeric_only=False, min_count=0):
         return Min(self, skipna, numeric_only, min_count)
 
@@ -1386,6 +1397,7 @@ from dask_expr.reductions import (
     IdxMin,
     Max,
     Mean,
+    MemoryUsage,
     Min,
     Mode,
     NBytes,

--- a/dask_expr/reductions.py
+++ b/dask_expr/reductions.py
@@ -408,6 +408,12 @@ class Mode(ApplyConcatApply):
         return {"dropna": self.dropna}
 
 
+class MemoryUsage(Reduction):
+    _parameters = ["frame", "deep", "index"]
+    _defaults = {"deep": False, "index": True}
+    pass
+
+
 class ValueCounts(Reduction):
     _defaults = {
         "sort": None,

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -120,6 +120,22 @@ def test_value_counts(df, pdf):
     assert_eq(df.x.value_counts(), pdf.x.value_counts())
 
 
+def test_memory_usage(pdf):
+    # Results are not equal with RangeIndex because pandas has one RangeIndex while
+    # we have one RangeIndex per partition
+    pdf.index = np.arange(len(pdf))
+    df = from_pandas(pdf)
+    assert_eq(df.memory_usage(), pdf.memory_usage())
+    assert_eq(df.memory_usage(index=False), pdf.memory_usage(index=False))
+    assert_eq(df.x.memory_usage(), pdf.x.memory_usage())
+    assert_eq(df.x.memory_usage(index=False), pdf.x.memory_usage(index=False))
+    assert_eq(df.index.memory_usage(), pdf.index.memory_usage())
+    with pytest.raises(
+        TypeError, match="index key-word is not supported when calculating"
+    ):
+        df.index.memory_usage(index=True)
+
+
 @pytest.mark.parametrize("func", [M.nlargest, M.nsmallest])
 def test_nlargest_nsmallest(df, pdf, func):
     assert_eq(func(df, n=5, columns="x"), func(pdf, n=5, columns="x"))

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -130,9 +130,7 @@ def test_memory_usage(pdf):
     assert_eq(df.x.memory_usage(), pdf.x.memory_usage())
     assert_eq(df.x.memory_usage(index=False), pdf.x.memory_usage(index=False))
     assert_eq(df.index.memory_usage(), pdf.index.memory_usage())
-    with pytest.raises(
-        TypeError, match="index key-word is not supported when calculating"
-    ):
+    with pytest.raises(TypeError, match="got an unexpected keyword"):
         df.index.memory_usage(index=True)
 
 


### PR DESCRIPTION
I think we need a general mechanism to pop not-needed keywords from the kwargs properties, otherwise we will run into similar problems in a bunch of methods.