### PR TITLE
Implement ``dropna`` and fix ``Blockwise`` apply bug

### DIFF
--- a/dask_expr/collection.py
+++ b/dask_expr/collection.py
@@ -511,6 +511,15 @@ class DataFrame(FrameBase):
             DropDuplicates(self.expr, subset=subset, ignore_index=ignore_index)
         )
 
+    def dropna(self, how=no_default, subset=None, thresh=no_default):
+        if how is not no_default and thresh is not no_default:
+            raise TypeError(
+                "You cannot set both the how and thresh arguments at the same time."
+            )
+        return new_collection(
+            expr.DropnaFrame(self.expr, how=how, subset=subset, thresh=thresh)
+        )
+
 
 class Series(FrameBase):
     """Series-like Expr Collection"""
@@ -548,6 +557,9 @@ class Series(FrameBase):
 
     def drop_duplicates(self, ignore_index=False):
         return new_collection(DropDuplicates(self.expr, ignore_index=ignore_index))
+
+    def dropna(self):
+        return new_collection(expr.DropnaSeries(self.expr))
 
 
 class Index(Series):

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -624,10 +624,8 @@ class Blockwise(Expr):
 
     @functools.cached_property
     def _meta(self):
-        func = lambda x: x._meta if isinstance(x, Expr) else x
-        args = [func(op) for op in self._args]
-        kwargs = {key: func(op) for key, op in self._kwargs.items()}
-        return self.operation(*args, **kwargs)
+        args = [op._meta if isinstance(op, Expr) else op for op in self._args]
+        return self.operation(*args, **self._kwargs)
 
     @functools.cached_property
     def _kwargs(self) -> dict:
@@ -697,15 +695,12 @@ class Blockwise(Expr):
         task: tuple
         """
         args = [self._blockwise_arg(op, index) for op in self._args]
-        kwargs = {
-            key: self._blockwise_arg(op, index) for key, op in self._kwargs.items()
-        }
-        if kwargs:
+        if self._kwargs:
             return (
                 apply,
                 self.operation,
                 (tuple, list(args)),
-                {**self._kwargs, **kwargs},
+                self._kwargs,
             )
         else:
             return (self.operation,) + tuple(args)

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -696,12 +696,7 @@ class Blockwise(Expr):
         """
         args = [self._blockwise_arg(op, index) for op in self._args]
         if self._kwargs:
-            return (
-                apply,
-                self.operation,
-                (tuple, list(args)),
-                self._kwargs,
-            )
+            return apply, self.operation, args, self._kwargs
         else:
             return (self.operation,) + tuple(args)
 

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -124,6 +124,14 @@ def test_value_counts(df, pdf):
     assert_eq(df.x.value_counts(), pdf.x.value_counts())
 
 
+def test_dropna(pdf):
+    pdf.loc[0, "y"] = np.nan
+    df = from_pandas(pdf)
+    assert_eq(df.dropna(), pdf.dropna())
+    assert_eq(df.dropna(how="all"), pdf.dropna(how="all"))
+    assert_eq(df.y.dropna(), pdf.y.dropna())
+
+
 def test_memory_usage(pdf):
     # Results are not equal with RangeIndex because pandas has one RangeIndex while
     # we have one RangeIndex per partition


### PR DESCRIPTION
A bunch of methods in pandas are kwargs only since 2.0 came out, Blockwise wasn't able to handle this right now. We can not convert everything to a kwargs dict, because some methods are positional only...

Happy to hear suggestions whether there is a better way of achieving this, my helper creates args and kwargs based on a variable. 

Blockwise had a small bug in the apply branch, which is fixed here