### PR TITLE
Implement ``GroupBy.__getitem__``

### DIFF
--- a/dask_expr/tests/test_groupby.py
+++ b/dask_expr/tests/test_groupby.py
@@ -53,6 +53,11 @@ def test_groupby_agg(pdf, df, spec):
     assert_eq(agg, expect)
 
 
+def test_groupby_getitem_agg(pdf, df):
+    assert_eq(df.groupby("x").y.sum(), pdf.groupby("x").y.sum())
+    assert_eq(df.groupby("x")[["y"]].sum(), pdf.groupby("x")[["y"]].sum())
+
+
 def test_groupby_agg_column_projection(pdf, df):
     g = df.groupby("x")
     agg = g.agg({"x": "count"}).simplify()


### PR DESCRIPTION
The logic is mostly from dask/dask.

The initial meta calculation couldn't work since it would always reduce to a Series with name None, passing the slice through should be more efficient. 

xref #92