### PR TITLE
Implement ``DataFrame.rename``

### DIFF
--- a/dask_expr/collection.py
+++ b/dask_expr/collection.py
@@ -16,7 +16,7 @@ from fsspec.utils import stringify_path
 from tlz import first
 
 from dask_expr import expr
-from dask_expr.expr import no_default
+from dask_expr.expr import RenameFrame, no_default
 from dask_expr.merge import Merge
 from dask_expr.reductions import (
     DropDuplicates,
@@ -519,6 +519,9 @@ class DataFrame(FrameBase):
         return new_collection(
             expr.DropnaFrame(self.expr, how=how, subset=subset, thresh=thresh)
         )
+
+    def rename(self, columns):
+        return new_collection(RenameFrame(self.expr, columns=columns))
 
 
 class Series(FrameBase):

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -5,6 +5,7 @@ import numbers
 import operator
 import os
 from collections import defaultdict
+from collections.abc import Mapping
 
 import dask
 import pandas as pd
@@ -778,6 +779,25 @@ class DropnaFrame(Blockwise):
     _defaults = {"how": no_default, "subset": None, "thresh": no_default}
     _keyword_only = ["how", "subset", "thresh"]
     operation = M.dropna
+
+
+class RenameFrame(Blockwise):
+    _parameters = ["frame", "columns"]
+    _keyword_only = ["columns"]
+    operation = M.rename
+
+    def _simplify_up(self, parent):
+        if isinstance(parent, Projection) and isinstance(self.columns, Mapping):
+            reverse_mapping = {val: key for key, val in self.columns.items()}
+            if not isinstance(parent.columns, pd.Index):
+                # Fill this out when Series.rename is implemented
+                return
+            else:
+                columns = [
+                    reverse_mapping[col] if col in reverse_mapping else col
+                    for col in self.columns
+                ]
+            return type(self)(self.frame[columns], *self.operands[1:])
 
 
 class Elemwise(Blockwise):

--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -787,15 +787,17 @@ class RenameFrame(Blockwise):
     operation = M.rename
 
     def _simplify_up(self, parent):
-        if isinstance(parent, Projection) and isinstance(self.columns, Mapping):
-            reverse_mapping = {val: key for key, val in self.columns.items()}
+        if isinstance(parent, Projection) and isinstance(
+            self.operand("columns"), Mapping
+        ):
+            reverse_mapping = {val: key for key, val in self.operand("columns").items()}
             if not isinstance(parent.columns, pd.Index):
                 # Fill this out when Series.rename is implemented
                 return
             else:
                 columns = [
                     reverse_mapping[col] if col in reverse_mapping else col
-                    for col in self.columns
+                    for col in parent.columns
                 ]
             return type(self)(self.frame[columns], *self.operands[1:])
 

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -210,6 +210,9 @@ def test_to_timestamp(pdf, how):
         lambda df: df.x.isna(),
         lambda df: df.abs(),
         lambda df: df.x.abs(),
+        lambda df: df.rename(columns={"x": "xx"}),
+        lambda df: df.rename(columns={"x": "xx"}).xx,
+        lambda df: df.rename(columns={"x": "xx"})[["xx"]],
     ],
 )
 def test_blockwise(func, pdf, df):

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -236,6 +236,12 @@ def test_repr(df):
     assert "sum(skipna=False)" in s
 
 
+def test_rename_traverse_filter(df):
+    result = optimize(df.rename(columns={"x": "xx"})[["xx"]], fuse=False)
+    expected = df[["x"]].rename(columns={"x": "xx"})
+    assert str(result) == str(expected)
+
+
 def test_columns_traverse_filters(pdf, df):
     result = optimize(df[df.x > 5].y, fuse=False)
     expected = df.y[df.x > 5]


### PR DESCRIPTION
Implemented this on DataFrame, what confused me a bit is that Dask disallows mutating the Index for a DataFrame but allows it on a Series. We should maybe think high level whether this is what we want before we invest time implementing anything on the Index.
