### PR TITLE
Support conversion between `dx.FrameBase` and `dd._Frame`

### DIFF
--- a/dask_expr/collection.py
+++ b/dask_expr/collection.py
@@ -339,7 +339,7 @@ class FrameBase(DaskMethodsMixin):
     def to_dask_dataframe(
         self, optimize_expr: bool = True, **optimize_kwargs
     ) -> _Frame:
-        """Convert to a Dask Dataframe collection
+        """Convert to a dask-dataframe collection
 
         Parameters
         ----------
@@ -655,7 +655,7 @@ def from_dask_dataframe(ddf: _Frame, optimize_graph: bool = True) -> FrameBase:
     Parameters
     ----------
     optimize_graph
-        Whether to optimize `ddf`'s graph before conversion.
+        Whether to optimize the graph before conversion.
     """
     graph = ddf.dask
     if optimize_graph:

--- a/dask_expr/collection.py
+++ b/dask_expr/collection.py
@@ -336,19 +336,17 @@ class FrameBase(DaskMethodsMixin):
 
         return new_collection(Repartition(self.expr, npartitions, divisions, force))
 
-    def to_dask_dataframe(
-        self, optimize_expr: bool = True, **optimize_kwargs
-    ) -> _Frame:
+    def to_dask_dataframe(self, optimize: bool = True, **optimize_kwargs) -> _Frame:
         """Convert to a dask-dataframe collection
 
         Parameters
         ----------
-        optimize_expr
+        optimize
             Whether to optimize the underlying `Expr` object before conversion.
         **optimize_kwargs
             Key-word arguments to pass through to `optimize`.
         """
-        df = optimize(self, **optimize_kwargs) if optimize_expr else self
+        df = self.optimize(**optimize_kwargs) if optimize else self
         return new_dd_object(df.dask, df._name, df._meta, df.divisions)
 
 
@@ -649,16 +647,16 @@ def from_graph(*args, **kwargs):
     return new_collection(FromGraph(*args, **kwargs))
 
 
-def from_dask_dataframe(ddf: _Frame, optimize_graph: bool = True) -> FrameBase:
+def from_dask_dataframe(ddf: _Frame, optimize: bool = True) -> FrameBase:
     """Create a dask-expr collection from a dask-dataframe collection
 
     Parameters
     ----------
-    optimize_graph
+    optimize
         Whether to optimize the graph before conversion.
     """
     graph = ddf.dask
-    if optimize_graph:
+    if optimize:
         graph = ddf.__dask_optimize__(graph, ddf.__dask_keys__())
     return from_graph(graph, ddf._meta, ddf.divisions, ddf._name)
 

--- a/dask_expr/collection.py
+++ b/dask_expr/collection.py
@@ -336,7 +336,9 @@ class FrameBase(DaskMethodsMixin):
 
         return new_collection(Repartition(self.expr, npartitions, divisions, force))
 
-    def to_dask_dataframe(self, optimize_expr: bool = True, **optimize_kwargs):
+    def to_dask_dataframe(
+        self, optimize_expr: bool = True, **optimize_kwargs
+    ) -> _Frame:
         """Convert to a Dask Dataframe collection
 
         Parameters
@@ -647,7 +649,7 @@ def from_graph(*args, **kwargs):
     return new_collection(FromGraph(*args, **kwargs))
 
 
-def from_dask_dataframe(ddf: _Frame, optimize_graph: bool = True):
+def from_dask_dataframe(ddf: _Frame, optimize_graph: bool = True) -> FrameBase:
     """Create a dask-expr collection from a dask-dataframe collection
 
     Parameters

--- a/dask_expr/io/io.py
+++ b/dask_expr/io/io.py
@@ -32,7 +32,7 @@ class FromGraph(IO):
         return self.operand("_name")
 
     def _layer(self):
-        return self.operand("layer")
+        return dict(self.operand("layer"))
 
 
 class BlockwiseIO(Blockwise, IO):

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -5,7 +5,8 @@ import pandas as pd
 import pytest
 from dask.dataframe.utils import assert_eq
 
-from dask_expr import from_pandas, optimize, read_csv, read_parquet
+from dask_expr import from_dask_dataframe, from_pandas, optimize, read_csv, read_parquet
+from dask_expr.expr import Expr
 from dask_expr.io import ReadParquet
 
 
@@ -204,3 +205,20 @@ def test_parquet_complex_filters(tmpdir):
 
     assert_eq(got, expect)
     assert_eq(got.optimize(), expect)
+
+
+@pytest.mark.parametrize("optimize_graph", [True, False])
+def test_from_dask_dataframe(optimize_graph):
+    ddf = dd.from_dict({"a": range(100)}, npartitions=10)
+    df = from_dask_dataframe(ddf, optimize_graph=optimize_graph)
+    assert isinstance(df.expr, Expr)
+    assert_eq(df, ddf)
+
+
+@pytest.mark.parametrize("optimize_expr", [True, False])
+def test_to_dask_dataframe(optimize_expr):
+    pdf = pd.DataFrame({"x": [1, 4, 3, 2, 0, 5]})
+    df = from_pandas(pdf, npartitions=2)
+    ddf = df.to_dask_dataframe(optimize_expr=optimize_expr)
+    assert isinstance(ddf, dd.DataFrame)
+    assert_eq(df, ddf)

--- a/dask_expr/io/tests/test_io.py
+++ b/dask_expr/io/tests/test_io.py
@@ -207,18 +207,18 @@ def test_parquet_complex_filters(tmpdir):
     assert_eq(got.optimize(), expect)
 
 
-@pytest.mark.parametrize("optimize_graph", [True, False])
-def test_from_dask_dataframe(optimize_graph):
+@pytest.mark.parametrize("optimize", [True, False])
+def test_from_dask_dataframe(optimize):
     ddf = dd.from_dict({"a": range(100)}, npartitions=10)
-    df = from_dask_dataframe(ddf, optimize_graph=optimize_graph)
+    df = from_dask_dataframe(ddf, optimize=optimize)
     assert isinstance(df.expr, Expr)
     assert_eq(df, ddf)
 
 
-@pytest.mark.parametrize("optimize_expr", [True, False])
-def test_to_dask_dataframe(optimize_expr):
+@pytest.mark.parametrize("optimize", [True, False])
+def test_to_dask_dataframe(optimize):
     pdf = pd.DataFrame({"x": [1, 4, 3, 2, 0, 5]})
     df = from_pandas(pdf, npartitions=2)
-    ddf = df.to_dask_dataframe(optimize_expr=optimize_expr)
+    ddf = df.to_dask_dataframe(optimize=optimize)
     assert isinstance(ddf, dd.DataFrame)
     assert_eq(df, ddf)


### PR DESCRIPTION
- Adds `FrameBase.to_dask_dataframe() -> dd._Frame`
- Adds `from_dask_dataframe(ddf: dd._Frame) -> FrameBase`

We will probably need this functionality down the road to support dask-expr/dask-dataframe integration and/or the "fallback" behavior proposed in https://github.com/mrocklin/dask-expr/issues/122