### PR TITLE
Add mechanism to search an expression graph for a given type

### DIFF
--- a/dask_expr/expr.py
+++ b/dask_expr/expr.py
@@ -5,7 +5,7 @@ import numbers
 import operator
 import os
 from collections import defaultdict
-from collections.abc import Mapping, Set
+from collections.abc import Mapping
 
 import dask
 import pandas as pd
@@ -635,31 +635,32 @@ class Expr:
         graphviz_to_file(g, filename, format)
         return g
 
-    def find_subtype(self, subtype: type) -> Set[Expr]:
-        """Search the expression graph for a specific `Expr` subtype
+    def find_operations(self, operation: type) -> list[Expr]:
+        """Search the expression graph for a specific operation type
 
         Parameters
         ----------
-        subtype
-            The `Expr` subtype to search for.
+        operation
+            The operation type to search for.
 
         Returns
         -------
-        nodes: set
-            Set of `subtype` instances.
+        nodes
+            List of `operation` instances. Ordering corresponds
+            to a depth-first search of the expression graph.
         """
 
-        assert issubclass(subtype, Expr), "`subtype` must be `Expr` subclass"
+        assert issubclass(operation, Expr), "`operation` must be `Expr` subclass"
         stack = [self]
-        seen, nodes = set(), set()
+        seen, nodes = set(), []
         while stack:
             node = stack.pop()
             if node._name in seen:
                 continue
             seen.add(node._name)
 
-            if isinstance(node, subtype):
-                nodes.add(node)
+            if isinstance(node, operation):
+                nodes.append(node)
 
             for dep in node.dependencies():
                 stack.append(dep)

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -595,3 +595,17 @@ def test_unique(df, pdf):
     # pandas returns a numpy array while we return a Series/Index
     assert_eq(df.x.unique(), pd.Series(pdf.x.unique(), name="x"))
     assert_eq(df.index.unique(), pd.Index(pdf.index.unique()))
+
+
+def test_find_subtype(df):
+    df2 = df[df["x"] > 1][["y"]] + 1
+
+    filters = df2.find_subtype(expr.Filter)
+    assert len(filters) == 1
+
+    projections = df2.find_subtype(expr.Projection)
+    assert len(projections) == 2
+
+    adds = df2.find_subtype(expr.Add)
+    assert len(adds) == 1
+    assert next(iter(adds))._name == df2._name

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -624,15 +624,15 @@ def test_unique(df, pdf):
     assert_eq(df.index.unique(), pd.Index(pdf.index.unique()))
 
 
-def test_find_subtype(df):
+def test_find_operations(df):
     df2 = df[df["x"] > 1][["y"]] + 1
 
-    filters = df2.find_subtype(expr.Filter)
+    filters = df2.find_operations(expr.Filter)
     assert len(filters) == 1
 
-    projections = df2.find_subtype(expr.Projection)
+    projections = df2.find_operations(expr.Projection)
     assert len(projections) == 2
 
-    adds = df2.find_subtype(expr.Add)
+    adds = df2.find_operations(expr.Add)
     assert len(adds) == 1
     assert next(iter(adds))._name == df2._name

--- a/dask_expr/tests/test_collection.py
+++ b/dask_expr/tests/test_collection.py
@@ -627,12 +627,12 @@ def test_unique(df, pdf):
 def test_find_operations(df):
     df2 = df[df["x"] > 1][["y"]] + 1
 
-    filters = df2.find_operations(expr.Filter)
+    filters = list(df2.find_operations(expr.Filter))
     assert len(filters) == 1
 
-    projections = df2.find_operations(expr.Projection)
+    projections = list(df2.find_operations(expr.Projection))
     assert len(projections) == 2
 
-    adds = df2.find_operations(expr.Add)
+    adds = list(df2.find_operations(expr.Add))
     assert len(adds) == 1
     assert next(iter(adds))._name == df2._name


### PR DESCRIPTION
While starting to add a `to_parquet` implementation, I found that it would be useful to have a simple mechanism to check if a specific `Expr` type is in the expression graph. For example, when overwriting a parquet dataset, it's good to make sure that we aren't reading from the same path earlier in the graph.