### PR TITLE
Pass reductions through shuffles

### DIFF
--- a/dask_expr/reductions.py
+++ b/dask_expr/reductions.py
@@ -515,23 +515,23 @@ class ValueCounts(ReductionConstantDim):
         return
 
 
-class MemoryUsageIndex(Reduction):
+class MemoryUsage(Reduction):
+    reduction_chunk = M.memory_usage
+    reduction_aggregate = M.sum
+
+
+class MemoryUsageIndex(MemoryUsage):
     _parameters = ["frame", "deep"]
     _defaults = {"deep": False}
-    reduction_chunk = M.memory_usage
-    reduction_combine = M.sum
-    reduction_aggregate = M.sum
 
     @property
     def chunk_kwargs(self):
         return {"deep": self.deep}
 
 
-class MemoryUsageFrame(Reduction):
+class MemoryUsageFrame(MemoryUsage):
     _parameters = ["frame", "deep", "_index"]
     _defaults = {"deep": False, "_index": True}
-    reduction_chunk = M.memory_usage
-    reduction_aggregate = M.sum
 
     @property
     def chunk_kwargs(self):

--- a/dask_expr/shuffle.py
+++ b/dask_expr/shuffle.py
@@ -22,6 +22,7 @@ from dask_expr.reductions import (
     All,
     Any,
     Count,
+    DropDuplicates,
     Len,
     Max,
     Mean,
@@ -125,6 +126,7 @@ class Shuffle(Expr):
             parent,
             (
                 Unique,
+                DropDuplicates,
                 Sum,
                 Prod,
                 Max,

--- a/dask_expr/shuffle.py
+++ b/dask_expr/shuffle.py
@@ -18,7 +18,25 @@ from dask.dataframe.shuffle import (
 from dask.utils import digit, get_default_shuffle_algorithm, insert
 
 from dask_expr.expr import Blockwise, Expr, PartitionsFiltered, Projection
-from dask_expr.reductions import Reduction
+from dask_expr.reductions import (
+    All,
+    Any,
+    Count,
+    Len,
+    Max,
+    Mean,
+    MemoryUsage,
+    Min,
+    Mode,
+    NBytes,
+    NLargest,
+    NSmallest,
+    Prod,
+    Size,
+    Sum,
+    Unique,
+    ValueCounts,
+)
 from dask_expr.repartition import Repartition
 
 
@@ -103,7 +121,28 @@ class Shuffle(Expr):
                     parent.operand("columns")
                 ]
 
-        if isinstance(parent, Reduction) and "idx" not in type(parent).__name__:
+        if isinstance(
+            parent,
+            (
+                Unique,
+                Sum,
+                Prod,
+                Max,
+                Any,
+                All,
+                Min,
+                Len,
+                Size,
+                NBytes,
+                Mean,
+                Count,
+                Mode,
+                NLargest,
+                NSmallest,
+                ValueCounts,
+                MemoryUsage,
+            ),
+        ):
             return type(parent)(self.frame, *parent.operands[1:])
 
     def _layer(self):

--- a/dask_expr/shuffle.py
+++ b/dask_expr/shuffle.py
@@ -18,6 +18,7 @@ from dask.dataframe.shuffle import (
 from dask.utils import digit, get_default_shuffle_algorithm, insert
 
 from dask_expr.expr import Blockwise, Expr, PartitionsFiltered, Projection
+from dask_expr.reductions import Reduction
 from dask_expr.repartition import Repartition
 
 
@@ -101,6 +102,9 @@ class Shuffle(Expr):
                 return type(self)(target[new_projection], *self.operands[1:])[
                     parent.operand("columns")
                 ]
+
+        if isinstance(parent, Reduction) and "idx" not in type(parent).__name__:
+            return type(parent)(self.frame, *parent.operands[1:])
 
     def _layer(self):
         raise NotImplementedError(

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -114,3 +114,12 @@ def test_shuffle_column_projection():
     df2 = df.shuffle("x")[["x"]].simplify()
 
     assert "y" not in df2.expr.operands[0].columns
+
+
+def test_shuffle_reductions():
+    pdf = pd.DataFrame({"x": list(range(20)) * 5, "y": range(100)})
+    df = from_pandas(pdf, npartitions=10)
+
+    assert df.shuffle("x").sum().optimize()._name == df.sum()._name  # This passes
+
+    assert df.shuffle("x").y.sum().optimize()._name == df.y.sum()._name  # This fails

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -122,4 +122,4 @@ def test_shuffle_reductions():
 
     assert df.shuffle("x").sum().optimize()._name == df.sum()._name  # This passes
 
-    assert df.shuffle("x").y.sum().optimize()._name == df.y.sum()._name  # This fails
+    # assert df.shuffle("x").y.sum().optimize()._name == df.y.sum()._name  # This fails

--- a/dask_expr/tests/test_shuffle.py
+++ b/dask_expr/tests/test_shuffle.py
@@ -5,11 +5,19 @@ from dask.dataframe.utils import assert_eq
 from dask_expr import from_pandas
 
 
+@pytest.fixture
+def pdf():
+    return pd.DataFrame({"x": list(range(20)) * 5, "y": range(100)})
+
+
+@pytest.fixture
+def df(pdf):
+    return from_pandas(pdf, npartitions=10)
+
+
 @pytest.mark.parametrize("ignore_index", [True, False])
 @pytest.mark.parametrize("npartitions", [3, 6])
-def test_disk_shuffle(ignore_index, npartitions):
-    pdf = pd.DataFrame({"x": list(range(20)) * 5, "y": range(100)})
-    df = from_pandas(pdf, npartitions=4)
+def test_disk_shuffle(ignore_index, npartitions, df):
     df2 = df.shuffle(
         "x",
         backend="disk",
@@ -46,9 +54,7 @@ def test_disk_shuffle(ignore_index, npartitions):
 @pytest.mark.parametrize("ignore_index", [True, False])
 @pytest.mark.parametrize("npartitions", [8, 12])
 @pytest.mark.parametrize("max_branch", [32, 6])
-def test_task_shuffle(ignore_index, npartitions, max_branch):
-    pdf = pd.DataFrame({"x": list(range(20)) * 5, "y": range(100)})
-    df = from_pandas(pdf, npartitions=10)
+def test_task_shuffle(ignore_index, npartitions, max_branch, df):
     df2 = df.shuffle(
         "x",
         backend="tasks",
@@ -85,9 +91,10 @@ def test_task_shuffle(ignore_index, npartitions, max_branch):
 
 @pytest.mark.parametrize("npartitions", [3, 12])
 @pytest.mark.parametrize("max_branch", [32, 8])
-def test_task_shuffle_index(npartitions, max_branch):
-    pdf = pd.DataFrame({"x": list(range(20)) * 5, "y": range(100)}).set_index("x")
-    df = from_pandas(pdf, npartitions=10)
+def test_task_shuffle_index(npartitions, max_branch, pdf):
+    pdf = pdf.set_index("x")
+    df = from_pandas(pdf, 10)
+
     df2 = df.shuffle(
         "x",
         backend="tasks",
@@ -108,18 +115,16 @@ def test_task_shuffle_index(npartitions, max_branch):
     assert sorted(df3.compute().tolist()) == list(range(20))
 
 
-def test_shuffle_column_projection():
-    pdf = pd.DataFrame({"x": list(range(20)) * 5, "y": range(100)})
-    df = from_pandas(pdf, npartitions=10)
+def test_shuffle_column_projection(df):
     df2 = df.shuffle("x")[["x"]].simplify()
 
     assert "y" not in df2.expr.operands[0].columns
 
 
-def test_shuffle_reductions():
-    pdf = pd.DataFrame({"x": list(range(20)) * 5, "y": range(100)})
-    df = from_pandas(pdf, npartitions=10)
+def test_shuffle_reductions(df):
+    assert df.shuffle("x").sum().optimize()._name == df.sum()._name
 
-    assert df.shuffle("x").sum().optimize()._name == df.sum()._name  # This passes
 
-    # assert df.shuffle("x").y.sum().optimize()._name == df.y.sum()._name  # This fails
+@pytest.mark.xfail(reason="Shuffle can't see the reduction through the Projection")
+def test_shuffle_reductions_after_projection(df):
+    assert df.shuffle("x").y.sum().optimize()._name == df.y.sum()._name


### PR DESCRIPTION
This is here mostly for comments.  In many (but not all) cases we should be able to pass reductions through shuffle operations.  For example:

```python
len(df.set_index(...)) == len(df)
```

This is easy to write, although we probably want to allow-list these rather than disallow them as we do today (IdxMax is a good example of a reduction where this isn't doable).

Additionally, we should also be able to do this with a projection in the middle:

```python
df.set_index(...).x.sum() == df.x.sum()
```

However we can't actually express this with today's optimizations because `_simplify_up` doesn't reach far enough up.  Interestingly this is a case where matchpy would have given us more than we can achieve with our current optimization infrastructure.

Probably short-term we should do the simple things and merge a cleaner version of this in.  I thought I'd leave it in this state though for discussion for a moment first.