### PR TITLE
Improve determinism of token used in `ReadParquet` caching

### DIFF
--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import itertools
 import operator
+import pickle
 from collections import defaultdict
 from functools import cached_property
 
@@ -226,10 +227,11 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
             return meta[column]
         return meta
 
-    @property
+    @cached_property
     def _plan(self):
         dataset_info = self._dataset_info
-        dataset_token = tokenize(dataset_info)
+        # Need to serialize dataset_info for deterministic tokenize result
+        dataset_token = tokenize(pickle.dumps(dataset_info))
         if dataset_token not in _cached_plan:
             parts, stats, common_kwargs = self.engine._construct_collection_plan(
                 dataset_info

--- a/dask_expr/io/parquet.py
+++ b/dask_expr/io/parquet.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import itertools
 import operator
-import pickle
 from collections import defaultdict
 from functools import cached_property
 
 import dask
+import pyarrow as pa
+import pyarrow.dataset as pa_ds
 import pyarrow.parquet as pq
-from dask.base import tokenize
+from dask.base import normalize_token, tokenize
 from dask.dataframe.io.parquet.core import (
     ParquetFunctionWrapper,
     aggregate_row_groups,
@@ -44,6 +45,21 @@ NONE_LABEL = "__null_dask_index__"
 # TODO: Allow _cached_dataset_info/_plan to contain >1 item?
 _cached_dataset_info = {}
 _cached_plan = {}
+
+
+@normalize_token.register(pa_ds.Dataset)
+def normalize_pa_ds(ds):
+    return (ds.files, ds.schema)
+
+
+@normalize_token.register(pa_ds.FileFormat)
+def normalize_pa_file_format(file_format):
+    return str(file_format)
+
+
+@normalize_token.register(pa.Schema)
+def normalize_pa_schema(schema):
+    return schema.to_string()
 
 
 class ReadParquet(PartitionsFiltered, BlockwiseIO):
@@ -230,8 +246,7 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
     @cached_property
     def _plan(self):
         dataset_info = self._dataset_info
-        # Need to serialize dataset_info for deterministic tokenize result
-        dataset_token = tokenize(pickle.dumps(dataset_info))
+        dataset_token = tokenize(dataset_info)
         if dataset_token not in _cached_plan:
             parts, stats, common_kwargs = self.engine._construct_collection_plan(
                 dataset_info


### PR DESCRIPTION
~Uses `pickle`~ (Adds new `normalize_token` definitions) to improve the caching of the `ReadParquet` partitioning "plan". I'm very open to other approaches.

**Related Discussion**

Note that this resolves some of the pain discussed in https://github.com/mrocklin/dask-expr/issues/131. However, some of that pain is bit more fundamental to how the `ReadParquet` expression works in general. More specifically, `ReadParquet` will not actually construct the partitioning plan until its `divisions` are queried, or when it's `__dask_graph__` method is called. Therefore, it is very possible for the original `dx.read_parquet` API call to return quickly, and for there to be a noticeable delay after a follow-up API call (or a `.simplify`/`.optimize`/`.dask` call).  This delay means that something have finally required `ReadParquet` to collect metadata, and since `ReadParquet` uses `Delayed` to parse the metadata on remote file systems, this delay sometimes corresponds to computation.